### PR TITLE
Get the correct C++11 ABI and other build options automatically from TensorFlow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,10 +42,14 @@ execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print
         OUTPUT_VARIABLE TENSORFLOW_INCLUDE_DIR )
 execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')" 
         OUTPUT_VARIABLE TENSORFLOW_LIB_DIR )
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; \
+        print(';'.join(flag[2:] for flag in tf.sysconfig.get_compile_flags() if flag.startswith('-D')), end='')"
+        OUTPUT_VARIABLE TENSORFLOW_COMPILE_DEFINITIONS )
 find_library( TENSORFLOW_FRAMEWORK_LIB tensorflow_framework PATHS "${TENSORFLOW_LIB_DIR}" NO_DEFAULT_PATH )
 message( STATUS "${TENSORFLOW_INCLUDE_DIR}" )
 message( STATUS "${TENSORFLOW_LIB_DIR}" )
 message( STATUS "${TENSORFLOW_FRAMEWORK_LIB}" )
+message( STATUS "TensorFlow compile definitions: ${TENSORFLOW_COMPILE_DEFINITIONS}" )
 
 configure_file( config.h.in config.h )
 if( BUILD_WITH_CUDA )
@@ -77,8 +81,7 @@ set_target_properties( lmbspecialops PROPERTIES PREFIX "" )
 set_target_properties( lmbspecialops PROPERTIES DEBUG_POSTFIX "_debug" )
 set_target_properties( lmbspecialops PROPERTIES COMPILE_FLAGS "${OpenMP_CXX_FLAGS}" )
 set_target_properties( lmbspecialops PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}" )
-# use old ABI with gcc 5.x
-set_target_properties( lmbspecialops PROPERTIES COMPILE_DEFINITIONS "_GLIBCXX_USE_CXX11_ABI=0" )
+set_target_properties( lmbspecialops PROPERTIES COMPILE_DEFINITIONS "${TENSORFLOW_COMPILE_DEFINITIONS}" )
 # enable c++11
 set_target_properties( lmbspecialops PROPERTIES 
                 CXX_STANDARD 11 


### PR DESCRIPTION
This fixes the issue seen in #10, which is caused by an ABI incompatibility between TensorFlow and lmbsepecialops.

lmbspecialops currently sets `_GLIBCXX_USE_CXX11_ABI=0`, which assumes that TensorFlow is built with an older C++ ABI and is the recommended setting in the [TensorFlow docs](https://www.tensorflow.org/install/source#bazel_build_options). However, some TensorFlow distributions do not follow this advice, i.e. the package provided in Anaconda.

Fortunately, since this is a common issue, TensorFlow provides the required build flags for ABI compatibility via `tf.sysconfig.get_compile_flags()` - "Get the compilation flags for custom operators.". 

```python
>>> tf.sysconfig.get_compile_flags()
['-I/home/martin/anaconda3/envs/dl/lib/python3.6/site-packages/tensorflow/include',
 '-D_GLIBCXX_USE_CXX11_ABI=1']
```

This PR replaces the hard-coded ABI setting with using all of the compile definitions (flags starting with `-D`) provided in `tf.sysconfig.get_compile_flags()` to build lmbspecialops.