### PR TITLE
Automatic configuration of CUDA gencode flags, easier installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,110 @@ CMakeCache.txt
 CMakeFiles
 __pycache__
 test/output*
+
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ release
 debug
 CMakeCache.txt
 CMakeFiles
+__pycache__
+test/output*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.5.1 )
+cmake_minimum_required( VERSION 3.8 )
 
 project(lmbspecialops)
 enable_testing()
@@ -12,7 +12,7 @@ option( BUILD_WITH_CUDA "If enabled builds cuda implementation of ops"  ON )
 # enable all warnings
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" )
 
-add_subdirectory( src lib ) 
-add_subdirectory( doc ) 
-add_subdirectory( test test ) 
+add_subdirectory( src lib )
+add_subdirectory( doc )
+add_subdirectory( test test )
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Checkout the repository and run `setup.py install`.
 ```bash
 git clone https://github.com/lmb-freiburg/lmbspecialops.git
 cd lmbspecialops
+pip install cmake-setuptools
 python setup.py install
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,46 +26,52 @@ See the [Op documentation](doc/lmbspecialops_doc.md) for a description of all fu
 Building and using lmbspecialops depends on the following libraries and programs
 
     tensorflow 1.4.0
-    cmake 3.7.1
+    cmake 3.8
     python 3.5
     cuda 8.0.61 (required for building with gpu support)
 
 The versions match the configuration we have tested on an ubuntu 16.04 system.
-lmbspecialops can work with other versions of the aforementioned dependencies, e.g. tensorflow 1.3, but this is not well tested.
+lmbspecialops can work with newer versions of the aforementioned dependencies, but this is not well tested.
 
 
+## Installation instructions
 
-## Build instructions
-
-
-Checkout the repository and setup the build directory.
+Checkout the repository and run `setup.py install`.
 
 ```bash
 git clone https://github.com/lmb-freiburg/lmbspecialops.git
 cd lmbspecialops
-
-mkdir build
-cd build
-cmake ..
-# cmake .. -DBUILD_WITH_CUDA=OFF # to disable gpu support
+python setup.py install
 ```
 
-Use ```ccmake``` to customize the configuration.
-You may want to adapt GPU code generation to your graphics card.
-E.g. to enable code generation for the Tesla K80 enable *GENERATE_KEPLER_SM37_CODE*
+NVCC's CUDA gencode parameters are configured automatically based on available GPU devices.
+
+If necessary, you can use the `CUDA_ARCH_LIST` environment variable or CMake variable to
+generate code for specific architectures or compute capabilities instead.
+`CUDA_ARCH_LIST` accepts a list of architecture names (e.g. Pascal, Volta, etc) and/or
+compute capability versions (6.1, 7.0, etc).
+
+To pass any parameters to CMake set the `CMAKE_COMMON_VARIABLES` environment variable. For example:
 
 ```bash
+export CUDA_ARCH_LIST="Pascal 7.0"
+export CMAKE_COMMON_VARIABLES="-DBUILD_WITH_CUDA=OFF" # to disable gpu support
+python setup.py install
+```
+
+Alternatively, you can use `ccmake` or `cmake-gui` inside the created build directory
+to configure any CMake variables.
+
+```bash
+python setup.py build_ext
+cd build/temp.*
 ccmake .
+make clean
+cd ../..
+python setup.py install
 ```
 
-Build the library
-
-```bash
-make
-```
-
-To use the ops, you need to add the ```lmbspecialops/python``` directory to your python path.
-Then you can import and use the ops like this 
+After installation you can import and use the ops like this 
 
 ```python
 import lmbspecialops
@@ -79,18 +85,20 @@ B = lmbspecialops.replace_nonfinite(A)
 print(B.eval()) # prints [1, 2, 0]
 ```
 
-    
+## Development
 
-### Virtualenv build 
+For development, it is preferable to use CMake directly without running `setup.py`.
+```bash
+mkdir build
+cd build
+cmake ..
+# cmake .. -DBUILD_WITH_CUDA=OFF # to disable gpu support
+make
+```
 
-To build inside a virtualenv make sure to activate the environment before
-running cmake.
+To use the ops, you need to add the `python` directory to your python path.
 
-If you encounter problems with cmake not finding the correct paths to your
-python interpreter or tensorflow see https://gist.github.com/datagrok/2199506
-for possible solutions.
-
-
+Use `make test` in the build directory to run tests.
 
 ## License
 

--- a/cmake/cuda_gencode_options.cmake
+++ b/cmake/cuda_gencode_options.cmake
@@ -1,66 +1,18 @@
 #
-# Provide options to configure the gencode string for the nvcc compiler
+# Provide options to configure the code generation options for the nvcc compiler
 #
 
-set( CUDA_GENCODE_STRING "")
+include( FindCUDA )
 
-option( GENERATE_PTX30_CODE "This will generate PTX 3.0 code" OFF )
-if( GENERATE_PTX30_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_30,code=compute_30" )
+if( DEFINED ENV{CUDA_ARCH_LIST} )
+    set( CUDA_ARCH_LIST $ENV{CUDA_ARCH_LIST} )
+else()
+    set( CUDA_ARCH_LIST Auto )
 endif()
+set( CUDA_ARCH_LIST ${CUDA_ARCH_LIST} CACHE LIST
+        "List of CUDA architectures (e.g. Pascal, Volta, etc) or \
+compute capability versions (6.1, 7.0, etc) to generate code for. \
+Set to Auto for automatic detection (default)." )
 
-option( GENERATE_KEPLER_SM30_CODE "This will generate code for the Kepler GPU architecture (sm_30)" OFF )
-if( GENERATE_KEPLER_SM30_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_30,code=sm_30" )
-endif()
-
-option( GENERATE_KEPLER_SM35_CODE "This will generate code for the Kepler GPU architecture (sm_35)" ON )
-if( GENERATE_KEPLER_SM35_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_35,code=sm_35" )
-endif()
-
-option( GENERATE_KEPLER_SM37_CODE "This will generate code for the Kepler GPU architecture (sm_37)" ON )
-if( GENERATE_KEPLER_SM37_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_37,code=sm_37" )
-endif()
-
-option( GENERATE_MAXWELL_SM50_CODE "This will generate code for the Maxwell GPU architecture (sm_50)" OFF )
-if( GENERATE_MAXWELL_SM50_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_50,code=sm_50" )
-endif()
-
-option( GENERATE_MAXWELL_SM52_CODE "This will generate code for the Maxwell GPU architecture (sm_52)" ON )
-if( GENERATE_MAXWELL_SM52_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_52,code=sm_52" )
-endif()
-
-option( GENERATE_PASCAL_SM60_CODE "This will generate code for the Pascal GPU architecture (sm_60)" ON )
-if( GENERATE_PASCAL_SM60_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_60,code=sm_60" )
-endif()
-
-option( GENERATE_PTX60_CODE "This will generate PTX 6.0 code" OFF )
-if( GENERATE_PTX60_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_60,code=compute_60" )
-endif()
-
-option( GENERATE_PASCAL_SM61_CODE "This will generate code for the Pascal GPU architecture (sm_61)" ON )
-if( GENERATE_PASCAL_SM61_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_61,code=sm_61" )
-endif()
-
-option( GENERATE_PTX61_CODE "This will generate PTX 6.1 code" OFF )
-if( GENERATE_PTX61_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_61,code=compute_61" )
-endif()
-
-option( GENERATE_VOLTA_SM70_CODE "This will generate code for the Pascal GPU architecture (sm_70)" OFF )
-if( GENERATE_VOLTA_SM70_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_70,code=sm_70" )
-endif()
-
-option( GENERATE_PTX70_CODE "This will generate PTX 7.0 code" OFF )
-if( GENERATE_PTX70_CODE )
-        list( APPEND CUDA_GENCODE_STRING "-gencode=arch=compute_70,code=compute_70" )
-endif()
-
+cuda_select_nvcc_arch_flags( CUDA_ARCH_FLAGS ${CUDA_ARCH_LIST} )
+message( STATUS "CUDA code generation flags: ${CUDA_ARCH_FLAGS}" )

--- a/cmake/tensorflow_build_flags.cmake
+++ b/cmake/tensorflow_build_flags.cmake
@@ -1,0 +1,20 @@
+#
+# Get build flags from tensorflow to build custom ops correctly
+#
+
+find_package( PythonInterp REQUIRED )
+
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_include(), end='')"
+        OUTPUT_VARIABLE TENSORFLOW_INCLUDE_DIR )
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')"
+        OUTPUT_VARIABLE TENSORFLOW_LIB_DIR )
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; \
+        print(';'.join(flag[2:] for flag in tf.sysconfig.get_compile_flags() if flag.startswith('-D')), end='')"
+        OUTPUT_VARIABLE TENSORFLOW_COMPILE_DEFINITIONS )
+
+find_library( TENSORFLOW_FRAMEWORK_LIB tensorflow_framework PATHS "${TENSORFLOW_LIB_DIR}" NO_DEFAULT_PATH )
+
+message( STATUS "${TENSORFLOW_INCLUDE_DIR}" )
+message( STATUS "${TENSORFLOW_LIB_DIR}" )
+message( STATUS "${TENSORFLOW_FRAMEWORK_LIB}" )
+message( STATUS "TensorFlow compile definitions: ${TENSORFLOW_COMPILE_DEFINITIONS}" )

--- a/patches/lz4_CMakeLists.txt
+++ b/patches/lz4_CMakeLists.txt
@@ -1,2 +1,2 @@
 cmake_minimum_required(VERSION 2.8)
-add_subdirectory( cmake_unofficial )
+add_subdirectory( contrib/cmake_unofficial )

--- a/python/lmbspecialops.py
+++ b/python/lmbspecialops.py
@@ -35,7 +35,7 @@ print('Using {0}'.format(_lib_path), flush=True)
 depth_to_flow = lmbspecialopslib.depth_to_flow
 depth_to_normals = lmbspecialopslib.depth_to_normals
 flow_to_depth2 = lmbspecialopslib.flow_to_depth2
-leaky_relu = lmbspecialopslib.leaky_relu
+leaky_relu = lmbspecialopslib.leaky_relu_lmb
 median3x3_downsample = lmbspecialopslib.median3x3_downsample
 replace_nonfinite = lmbspecialopslib.replace_nonfinite
 scale_invariant_gradient = lmbspecialopslib.scale_invariant_gradient
@@ -316,9 +316,9 @@ def _replace_nonfinite_grad(op, grad):
         input=op.inputs[0])
 
 
-@ops.RegisterGradient("LeakyRelu")
-def _leaky_relu_grad(op, grad):
-    return lmbspecialopslib.leaky_relu_grad(
+@ops.RegisterGradient("LeakyReluLmb")
+def _leaky_relu_lmb_grad(op, grad):
+    return lmbspecialopslib.leaky_relu_lmb_grad(
         gradients=grad,
         input=op.inputs[0],
         leak=op.get_attr('leak'))

--- a/python/lmbspecialops.py
+++ b/python/lmbspecialops.py
@@ -1,17 +1,17 @@
 #
 #  lmbspecialops - a collection of tensorflow ops
 #  Copyright (C) 2017  Benjamin Ummenhofer, Huizhong Zhou
-#  
+#
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
@@ -40,6 +40,12 @@ median3x3_downsample = lmbspecialopslib.median3x3_downsample
 replace_nonfinite = lmbspecialopslib.replace_nonfinite
 scale_invariant_gradient = lmbspecialopslib.scale_invariant_gradient
 warp2d = lmbspecialopslib.warp2d
+
+flow_warp = lmbspecialopslib.flow_warp
+correlation = lmbspecialopslib.correlation
+correlation_1d = lmbspecialopslib.correlation1d
+flow_out_of_frame = lmbspecialopslib.flow_out_of_frame
+
 
 # Author: Lukas Voegtle <voegtlel@tf.uni-freiburg.de>
 def resample(input, size, antialias=False):
@@ -280,13 +286,13 @@ def flow_to_depth(flow, intrinsics, rotation, translation, rotation_format=None,
     if not nowarning:
         warnings.warn("flow_to_depth has incorrect behaviour but is kept for compatibility. Please use flow_to_depth2", DeprecationWarning, stacklevel=2)
     return lmbspecialopslib.flow_to_depth(
-            flow=flow, 
-            intrinsics=intrinsics, 
-            rotation=rotation, 
-            translation=translation, 
-            rotation_format=rotation_format, 
-            inverse_depth=inverse_depth, 
-            normalized_flow=normalized_flow, 
+            flow=flow,
+            intrinsics=intrinsics,
+            rotation=rotation,
+            translation=translation,
+            rotation_format=rotation_format,
+            inverse_depth=inverse_depth,
+            normalized_flow=normalized_flow,
             name=name)
 flow_to_depth.__doc__ = lmbspecialopslib.flow_to_depth.__doc__
 
@@ -316,4 +322,35 @@ def _leaky_relu_grad(op, grad):
         input=op.inputs[0],
         leak=op.get_attr('leak'))
 
+@ops.RegisterGradient("FlowWarp")
+def _flow_warp_grad(op, grad):
+    return lmbspecialopslib.flow_warp_grad(
+            gradient=grad,
+            image=op.inputs[0],
+            flow=op.inputs[1])
 
+@ops.RegisterGradient("Correlation")
+def _correlation_grad(op, grad):
+    return lmbspecialopslib.correlation_grad(
+            gradient=grad,
+            input1=op.inputs[0],
+            input2=op.inputs[1],
+            kernel_size=op.get_attr('kernel_size'),
+            max_displacement=op.get_attr('max_displacement'),
+            stride1=op.get_attr('stride1'),
+            stride2=op.get_attr('stride2'),
+            pad_size=op.get_attr('pad_size') )
+
+@ops.RegisterGradient("Correlation1D")
+def _correlation_1d_grad(op, grad):
+    return lmbspecialopslib.correlation1d_grad(
+            gradient=grad,
+            input1=op.inputs[0],
+            input2=op.inputs[1],
+            kernel_size=op.get_attr('kernel_size'),
+            max_displacement=op.get_attr('max_displacement'),
+            stride1=op.get_attr('stride1'),
+            stride2=op.get_attr('stride2'),
+            pad_size=op.get_attr('pad_size'),
+            single_dir=op.get_attr('single_dir')
+            )

--- a/python/lmbspecialops.py
+++ b/python/lmbspecialops.py
@@ -45,18 +45,19 @@ flow_warp = lmbspecialopslib.flow_warp
 correlation = lmbspecialopslib.correlation
 correlation_1d = lmbspecialopslib.correlation1d
 flow_out_of_frame = lmbspecialopslib.flow_out_of_frame
+resample = lmbspecialopslib.resample
 
-
+# Remove this?
 # Author: Lukas Voegtle <voegtlel@tf.uni-freiburg.de>
-def resample(input, size, antialias=False):
-    """
-    Resamples the given input tensor to a given size.
-    :param input: dtype input tensor [batch, height, width, channels]
-    :param size: new size (height, width)
-    :param antialias: perform antialiasing iff downsampling
-    :return: resized tensor
-    """
-    return lmbspecialopslib.resample(input, size, antialias=antialias)
+#def resample(input, size, antialias=False):
+#    """
+#    Resamples the given input tensor to a given size.
+#    :param input: dtype input tensor [batch, height, width, channels]
+#    :param size: new size (height, width)
+#    :param antialias: perform antialiasing iff downsampling
+#    :return: resized tensor
+#    """
+#    return lmbspecialopslib.resample(input, size, antialias=antialias)
 
 
 # Author: Lukas Voegtle <voegtlel@tf.uni-freiburg.de>

--- a/python/lmbspecialops/__init__.py
+++ b/python/lmbspecialops/__init__.py
@@ -20,13 +20,23 @@ from tensorflow.python.framework import ops
 import os
 import warnings
 
+_lib_path = None
 if 'LMBSPECIALOPS_LIB' in os.environ:
     _lib_path = os.environ['LMBSPECIALOPS_LIB']
-else:  # try to find the lib in the build directory relative to this file
-    _lib_path = os.path.abspath(os.path.join(os.path.split(__file__)[0], '..', 'build', 'lib', 'lmbspecialops.so'))
-if not os.path.isfile(_lib_path):
+else:
+    _script_dir = os.path.dirname(__file__)
+    _potential_paths = [
+        os.path.abspath(os.path.join(_script_dir, 'lmbspecialops.so')),
+        os.path.abspath(os.path.join(_script_dir, '..', 'lmbspecialops.so')),
+        os.path.abspath(os.path.join(_script_dir, '..', 'build', 'lib', 'lmbspecialops.so')),
+    ]
+    for p in _potential_paths:
+        if os.path.isfile(p):
+            _lib_path = p
+            break
+if not _lib_path or not os.path.isfile(_lib_path):
     raise ValueError(
-        'Cannot find lmbspecialops.so . Set the environment variable LMBSPECIALOPS_LIB to the path to lmbspecialops.so file')
+        'Cannot find lmbspecialops.so. Set the environment variable LMBSPECIALOPS_LIB to the path to lmbspecialops.so file')
 lmbspecialopslib = tf.load_op_library(_lib_path)
 print('Using {0}'.format(_lib_path), flush=True)
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@ from setuptools import setup
 
 setup(
     name='lmbspecialops',
+    description='A python wrapper for tf to ease creation of network definitions',
+    version='A collection of tensorflow ops',
+    url='https://github.com/lmb-freiburg/lmbspecialops',
+    license='GPLv3.0',
+    author='lmb-freiburg',
+    author_email='',
+    python_requires='>=3.5',
     setup_requires=['cmake-setuptools', 'tensorflow'],
     ext_modules=[CMakeExtension('lmbspecialops')],
     cmdclass={'build_ext': CMakeBuildExt},

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from cmake_setuptools import CMakeExtension, CMakeBuildExt
+from setuptools import setup
+
+setup(
+    name='lmbspecialops',
+    setup_requires=['cmake-setuptools', 'tensorflow'],
+    ext_modules=[CMakeExtension('lmbspecialops')],
+    cmdclass={'build_ext': CMakeBuildExt},
+    package_dir={'': 'python'},
+    packages=['lmbspecialops'],
+    zip_safe=False,
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,8 @@ include(ExternalProject)
 ExternalProject_Add(
         webp
         PREFIX "${CMAKE_BINARY_DIR}/webp"
-        URL "http://downloads.webmproject.org/releases/webp/libwebp-0.6.0.tar.gz"
+        URL "http://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.2.tar.gz"
+        URL_MD5 02c0c55f1dd8612cd4d462e3409ad35d
         # do not update
         UPDATE_COMMAND ""
         # compile with PIC because caffe builds a shared object
@@ -20,7 +21,8 @@ set( webp_LIBRARY "${BINARY_DIR}/src/.libs/libwebp.a" )
 ExternalProject_Add(
         lz4
         PREFIX "${CMAKE_BINARY_DIR}/lz4"
-        URL "https://github.com/lz4/lz4/archive/r131.tar.gz"
+        URL "https://github.com/lz4/lz4/archive/v1.9.1.tar.gz"
+        URL_MD5 a80f28f2a2e5fe59ebfe8407f793da22
         # do not update
         UPDATE_COMMAND ""
         # fix missing CMakeLists.txt in source root dir
@@ -30,7 +32,7 @@ ExternalProject_Add(
 )
 ExternalProject_Get_Property( lz4 SOURCE_DIR BINARY_DIR )
 set( lz4_INCLUDE_DIR "${SOURCE_DIR}/lib" )
-set( lz4_STATIC_LIB ${BINARY_DIR}/cmake_unofficial/liblz4.a )
+set( lz4_STATIC_LIB ${BINARY_DIR}/contrib/cmake_unofficial/liblz4.a )
 
 
 find_package( PythonInterp REQUIRED )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 include( ExternalProject )
 
+# webp
 ExternalProject_Add(
         webp
         PREFIX "${CMAKE_BINARY_DIR}/webp"
@@ -35,23 +36,9 @@ set( lz4_INCLUDE_DIR "${SOURCE_DIR}/lib" )
 set( lz4_STATIC_LIB ${BINARY_DIR}/contrib/cmake_unofficial/liblz4.a )
 
 
-find_package( PythonInterp REQUIRED )
 find_package( OpenMP REQUIRED )
 
-
-# retrieve tensorflow include dir and lib dir
-execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_include(), end='')"
-        OUTPUT_VARIABLE TENSORFLOW_INCLUDE_DIR )
-execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')"
-        OUTPUT_VARIABLE TENSORFLOW_LIB_DIR )
-execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; \
-        print(';'.join(flag[2:] for flag in tf.sysconfig.get_compile_flags() if flag.startswith('-D')), end='')"
-        OUTPUT_VARIABLE TENSORFLOW_COMPILE_DEFINITIONS )
-find_library( TENSORFLOW_FRAMEWORK_LIB tensorflow_framework PATHS "${TENSORFLOW_LIB_DIR}" NO_DEFAULT_PATH )
-message( STATUS "${TENSORFLOW_INCLUDE_DIR}" )
-message( STATUS "${TENSORFLOW_LIB_DIR}" )
-message( STATUS "${TENSORFLOW_FRAMEWORK_LIB}" )
-message( STATUS "TensorFlow compile definitions: ${TENSORFLOW_COMPILE_DEFINITIONS}" )
+include( "${CMAKE_SOURCE_DIR}/cmake/tensorflow_build_flags.cmake" )
 
 configure_file( config.h.in config.h )
 if( BUILD_WITH_CUDA )
@@ -64,7 +51,6 @@ endif()
 
 file( GLOB lmbspecialops_SOURCES *.cc *.c )
 file( GLOB lmbspecialops_CUSOURCES *.cu )
-
 
 include_directories(
         ${TENSORFLOW_INCLUDE_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,10 +42,14 @@ execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print
         OUTPUT_VARIABLE TENSORFLOW_INCLUDE_DIR )
 execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')" 
         OUTPUT_VARIABLE TENSORFLOW_LIB_DIR )
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; \
+        print(';'.join(flag[2:] for flag in tf.sysconfig.get_compile_flags() if flag.startswith('-D')), end='')"
+        OUTPUT_VARIABLE TENSORFLOW_COMPILE_DEFINITIONS )
 find_library( TENSORFLOW_FRAMEWORK_LIB tensorflow_framework PATHS "${TENSORFLOW_LIB_DIR}" NO_DEFAULT_PATH )
 message( STATUS "${TENSORFLOW_INCLUDE_DIR}" )
 message( STATUS "${TENSORFLOW_LIB_DIR}" )
 message( STATUS "${TENSORFLOW_FRAMEWORK_LIB}" )
+message( STATUS "TensorFlow compile definitions: ${TENSORFLOW_COMPILE_DEFINITIONS}" )
 
 configure_file( config.h.in config.h )
 if( BUILD_WITH_CUDA )
@@ -77,8 +81,7 @@ set_target_properties( lmbspecialops PROPERTIES PREFIX "" )
 set_target_properties( lmbspecialops PROPERTIES DEBUG_POSTFIX "_debug" )
 set_target_properties( lmbspecialops PROPERTIES COMPILE_FLAGS "${OpenMP_CXX_FLAGS}" )
 set_target_properties( lmbspecialops PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}" )
-# use old ABI with gcc 5.x
-set_target_properties( lmbspecialops PROPERTIES COMPILE_DEFINITIONS "_GLIBCXX_USE_CXX11_ABI=0" )
+set_target_properties( lmbspecialops PROPERTIES COMPILE_DEFINITIONS "${TENSORFLOW_COMPILE_DEFINITIONS}" )
 # enable c++11
 set_target_properties( lmbspecialops PROPERTIES 
                 CXX_STANDARD 11 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(ExternalProject)
+include( ExternalProject )
 
 ExternalProject_Add(
         webp
@@ -8,7 +8,7 @@ ExternalProject_Add(
         # do not update
         UPDATE_COMMAND ""
         # compile with PIC because caffe builds a shared object
-        CONFIGURE_COMMAND CFLAGS=-fPIC ../webp/configure --disable-gl --disable-png --disable-jpeg  --disable-tiff --disable-gif --disable-wic --disable-shared
+        CONFIGURE_COMMAND CFLAGS=-fPIC ../webp/configure --disable-gl --disable-png --disable-jpeg --disable-tiff --disable-gif --disable-wic --disable-shared
         BUILD_COMMAND "make"
         # do not install
         INSTALL_COMMAND ""
@@ -40,9 +40,9 @@ find_package( OpenMP REQUIRED )
 
 
 # retrieve tensorflow include dir and lib dir
-execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_include(), end='')" 
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_include(), end='')"
         OUTPUT_VARIABLE TENSORFLOW_INCLUDE_DIR )
-execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')" 
+execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')"
         OUTPUT_VARIABLE TENSORFLOW_LIB_DIR )
 execute_process( COMMAND ${PYTHON_EXECUTABLE} "-c" "from __future__ import print_function; import tensorflow as tf; \
         print(';'.join(flag[2:] for flag in tf.sysconfig.get_compile_flags() if flag.startswith('-D')), end='')"
@@ -55,28 +55,27 @@ message( STATUS "TensorFlow compile definitions: ${TENSORFLOW_COMPILE_DEFINITION
 
 configure_file( config.h.in config.h )
 if( BUILD_WITH_CUDA )
-        find_package( CUDA REQUIRED )
-        include( "${CMAKE_SOURCE_DIR}/cmake/cuda_gencode_options.cmake" )
-        list( APPEND CUDA_NVCC_FLAGS "-std=c++11")
-        list( APPEND CUDA_NVCC_FLAGS "${CUDA_GENCODE_STRING}" )
-        list( APPEND CUDA_NVCC_FLAGS_DEBUG -g -G -O0 --ptxas-options=-v )
-
+    find_package( CUDA REQUIRED )
+    include( "${CMAKE_SOURCE_DIR}/cmake/cuda_gencode_options.cmake" )
+    list( APPEND CUDA_NVCC_FLAGS -std=c++11 )
+    list( APPEND CUDA_NVCC_FLAGS ${CUDA_ARCH_FLAGS} )
+    list( APPEND CUDA_NVCC_FLAGS_DEBUG -g -G -O0 --ptxas-options=-v )
 endif()
 
-file( GLOB lmbspecialops_SOURCES  *.cc *.c )
+file( GLOB lmbspecialops_SOURCES *.cc *.c )
 file( GLOB lmbspecialops_CUSOURCES *.cu )
 
 
-include_directories( 
-    ${TENSORFLOW_INCLUDE_DIR}
-    ${TENSORFLOW_INCLUDE_DIR}/external/nsync/public/  # fix nsync headers not found bug
+include_directories(
+        ${TENSORFLOW_INCLUDE_DIR}
+        ${TENSORFLOW_INCLUDE_DIR}/external/nsync/public/  # fix nsync headers not found bug
         ${PROJECT_BINARY_DIR}/lib
 )
 
 if( BUILD_WITH_CUDA )
-        cuda_add_library( lmbspecialops SHARED ${lmbspecialops_SOURCES} ${lmbspecialops_CUSOURCES} )
+    cuda_add_library( lmbspecialops SHARED ${lmbspecialops_SOURCES} ${lmbspecialops_CUSOURCES} )
 else()
-        add_library( lmbspecialops SHARED ${lmbspecialops_SOURCES} )
+    add_library( lmbspecialops SHARED ${lmbspecialops_SOURCES} )
 endif()
 # do not add 'lib' prefix
 set_target_properties( lmbspecialops PROPERTIES PREFIX "" )
@@ -85,10 +84,10 @@ set_target_properties( lmbspecialops PROPERTIES COMPILE_FLAGS "${OpenMP_CXX_FLAG
 set_target_properties( lmbspecialops PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}" )
 set_target_properties( lmbspecialops PROPERTIES COMPILE_DEFINITIONS "${TENSORFLOW_COMPILE_DEFINITIONS}" )
 # enable c++11
-set_target_properties( lmbspecialops PROPERTIES 
-                CXX_STANDARD 11 
-                CXX_STANDARD_REQUIRED ON 
-                CXX_EXTENSIONS OFF)
+set_target_properties( lmbspecialops PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF )
 
 add_dependencies( lmbspecialops lz4 webp )
 
@@ -102,5 +101,5 @@ target_link_libraries( lmbspecialops
         ${webp_LIBRARY}
 )
 if( TENSORFLOW_FRAMEWORK_LIB )
-        target_link_libraries( lmbspecialops ${TENSORFLOW_FRAMEWORK_LIB} )
+    target_link_libraries( lmbspecialops ${TENSORFLOW_FRAMEWORK_LIB} )
 endif()

--- a/src/correlation.cc
+++ b/src/correlation.cc
@@ -1,0 +1,128 @@
+//
+//  lmbspecialops - a collection of tensorflow ops
+//  Copyright (C) 2017  Oezguen Cicek, Eddy Ilg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "config.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Correlation")
+  .Attr("T: {float}")
+  .Attr("corr_type: {'mult', 'subt'} = 'mult'")
+  .Attr("max_displacement: int")
+  .Attr("kernel_size: int")
+  .Attr("stride1: int = 1")
+  .Attr("stride2: int = 1")
+  .Attr("pad_size: int = 0")
+  .Attr("do_abs: bool = false")
+  .Input("input1: T")
+  .Input("input2: T")
+  .Output("output: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      // check if both inputs have rank 4
+      using namespace ::tensorflow::shape_inference;
+      ShapeHandle input1_shape, input2_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input1_shape));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &input2_shape));
+
+      ShapeHandle merged_shape4d;
+      TF_RETURN_IF_ERROR(c->Merge(input1_shape, input2_shape, &merged_shape4d));
+
+      int kernel_size, max_displacement, pad_size, stride1, stride2;
+
+      // Get attributes
+      TF_RETURN_IF_ERROR(c->GetAttr("kernel_size", &kernel_size));
+      TF_RETURN_IF_ERROR(c->GetAttr("max_displacement", &max_displacement));
+      TF_RETURN_IF_ERROR(c->GetAttr("pad_size", &pad_size));
+      TF_RETURN_IF_ERROR(c->GetAttr("stride1", &stride1));
+      TF_RETURN_IF_ERROR(c->GetAttr("stride2", &stride2));
+
+      int num      = c->Value(c->Dim(input1_shape, 0));
+      int channels = c->Value(c->Dim(input1_shape, 1));
+      int height   = c->Value(c->Dim(input1_shape, 2));
+      int width    = c->Value(c->Dim(input1_shape, 3));
+
+      int paddedbottomheight = height+2*pad_size;
+      int paddedbottomwidth = width+2*pad_size;
+
+      // Size computation
+      int kernel_radius = (kernel_size - 1) / 2; //size of unreachable border region (on each side)
+      int border_size = max_displacement + kernel_radius; //size of unreachable border region (on each side)
+
+      int top_width = ceil((float)(paddedbottomwidth - border_size*2) / (float)stride1);
+      int top_height = ceil((float)(paddedbottomheight - border_size*2) / (float)stride1);
+
+      // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+      int neighborhood_grid_radius = max_displacement / stride2;
+      int neighborhood_grid_width = neighborhood_grid_radius * 2 + 1;
+
+      // Top Channels amount to displacement combinations in X and Y direction:
+      int top_channels = neighborhood_grid_width * neighborhood_grid_width;
+
+      // make sure warped has the same size as image
+      c->set_output(0, c->MakeShape({num, top_channels, top_height, top_width}));
+
+      return Status::OK();
+    })
+  .Doc(R"doc(
+Correlates patches from the first input image with patches from
+the second input image.
+
+Let K be the kernel size and N be the neighborhoud size.
+For a K x K patch from the first image, (N-K+1)^2 patches from the
+second image are compared to it.
+
+input1:
+  Input tensor of rank 4 and data format "NCHW".
+
+input2:
+  Input tensor of rank 4 and data format "NCHW".
+
+output:
+  If W and H are the spatial input dimensions, this results in an output blob of
+    For stride 1:
+    Width: (W-K+1)
+    Height: (H-K+1)
+    Channels: N^2
+)doc");
+
+REGISTER_OP("CorrelationGrad")
+  .Attr("T: {float}")
+  .Attr("corr_type: {'mult', 'subt'} = 'mult'")
+  .Attr("max_displacement: int")
+  .Attr("kernel_size: int")
+  .Attr("stride1: int = 1")
+  .Attr("stride2: int = 1")
+  .Attr("pad_size: int = 0")
+  .Attr("do_abs: bool = false")
+  .Input("input1: T")
+  .Input("input2: T")
+  .Input("gradient: T")
+  .Output("input1_grad: T")
+  .Output("input2_grad: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      c->set_output(0, c->input(0));
+      c->set_output(1, c->input(1));
+      return Status::OK();
+    })
+  .Doc(R"doc(
+This computes the gradient for the op 'Correlation'.
+)doc");

--- a/src/correlation_1d.cc
+++ b/src/correlation_1d.cc
@@ -1,0 +1,118 @@
+#include "config.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Correlation1D")
+  .Attr("T: {float}")
+  .Attr("corr_type: {'mult', 'subt'} = 'mult'")
+  .Attr("max_displacement: int")
+  .Attr("kernel_size: int")
+  .Attr("stride1: int = 1")
+  .Attr("stride2: int = 1")
+  .Attr("pad_size: int = 0")
+  .Attr("do_abs: bool = false")
+  .Attr("single_dir: int = 0")
+  .Input("input1: T")
+  .Input("input2: T")
+  .Output("output: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      // check if both inputs have rank 4
+      using namespace ::tensorflow::shape_inference;
+      ShapeHandle input1_shape, input2_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input1_shape));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &input2_shape));
+
+      ShapeHandle merged_shape4d;
+      TF_RETURN_IF_ERROR(c->Merge(input1_shape, input2_shape, &merged_shape4d));
+
+      int kernel_size, max_displacement, pad_size, stride1, stride2, single_dir;
+
+      // Get attributes
+      TF_RETURN_IF_ERROR(c->GetAttr("kernel_size", &kernel_size));
+      TF_RETURN_IF_ERROR(c->GetAttr("max_displacement", &max_displacement));
+      TF_RETURN_IF_ERROR(c->GetAttr("single_dir", &single_dir));
+      TF_RETURN_IF_ERROR(c->GetAttr("pad_size", &pad_size));
+      TF_RETURN_IF_ERROR(c->GetAttr("stride1", &stride1));
+      TF_RETURN_IF_ERROR(c->GetAttr("stride2", &stride2));
+
+      int num      = c->Value(c->Dim(input1_shape, 0));
+      int channels = c->Value(c->Dim(input1_shape, 1));
+      int height   = c->Value(c->Dim(input1_shape, 2));
+      int width    = c->Value(c->Dim(input1_shape, 3));
+
+      int paddedbottomheight = height;
+      int paddedbottomwidth = width+2*pad_size;
+
+      // Size computation
+      int kernel_radius = (kernel_size - 1) / 2; //size of unreachable border region (on each side)
+      int border_size = max_displacement + kernel_radius; //size of unreachable border region (on each side)
+
+      int top_width = ceil((float)(paddedbottomwidth - border_size*2) / (float)stride1);
+      int top_height = ceil((float)(paddedbottomheight - kernel_radius*2) / (float)stride1);
+
+      // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+      int neighborhood_grid_radius = max_displacement / stride2;
+      int neighborhood_grid_width;
+
+	  if(single_dir != 0) {
+			neighborhood_grid_width = neighborhood_grid_radius + 1;
+		} else {
+			neighborhood_grid_width = neighborhood_grid_radius * 2 + 1;
+		}
+      // Top Channels amount to displacement in X direction
+      int top_channels = neighborhood_grid_width;
+
+      // make sure warped has the same size as image
+      c->set_output(0, c->MakeShape({num, top_channels, top_height, top_width}));
+
+      return Status::OK();
+    })
+  .Doc(R"doc(
+Correlates two feature maps in X direction.
+
+Let K be the kernel size and N be the neighborhoud size.
+For a K x K patch from the first image, (N-K+1) patches from the
+second image are compared to it.
+
+input1:
+  Input tensor of rank 4 and data format "NCHW".
+
+input2:
+  Input tensor of rank 4 and data format "NCHW".
+
+output:
+  If W and H are the spatial input dimensions, this results in an output blob of
+    For stride 1:
+    Width: (W-K+1)
+    Height: (H-K+1)
+    Channels: N
+)doc");
+
+REGISTER_OP("Correlation1DGrad")
+  .Attr("T: {float}")
+  .Attr("corr_type: {'mult', 'subt'} = 'mult'")
+  .Attr("max_displacement: int")
+  .Attr("kernel_size: int")
+  .Attr("stride1: int = 1")
+  .Attr("stride2: int = 1")
+  .Attr("pad_size: int = 0")
+  .Attr("do_abs: bool = false")
+  .Attr("single_dir: int = 0")
+  .Input("input1: T")
+  .Input("input2: T")
+  .Input("gradient: T")
+  .Output("input1_grad: T")
+  .Output("input2_grad: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      c->set_output(0, c->input(0));
+      c->set_output(1, c->input(1));
+      return Status::OK();
+    })
+  .Doc(R"doc(
+This computes the gradient for the op 'Correlation1D'.
+)doc");

--- a/src/correlation_1d_cuda.cu
+++ b/src/correlation_1d_cuda.cu
@@ -1,0 +1,915 @@
+#define EIGEN_USE_GPU
+#include "config.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "helper.h"
+#include "cuda_helper.h"
+#include "Eigen/Core"
+
+#define ROUND_OFF 50000
+
+#define WARPS_PER_BLOCK 1
+#define THREADS_PER_WARP 32
+
+using namespace tensorflow;
+
+// == Dimension rearrangement Kernel
+namespace blob_rearrange_kernel2_internal
+{
+template <class T>
+__global__ void blob_rearrange_kernel2_1D(const T* in, T* out, int num, int channels, int width, int height, int widthheight, int padding, int pwidthheight)
+{
+    int xy = blockIdx.x*blockDim.x + threadIdx.x;
+    if(xy>=widthheight)
+        return;
+
+    int ch = blockIdx.y;
+    int n  = blockIdx.z;
+
+    T value=in[(n*channels+ch)*widthheight+xy];
+
+    __syncthreads();
+
+    int xpad  = (xy % width + padding);
+    int ypad  = (xy / width + 0);
+    int xypad = ypad * (width+2*padding) + xpad;
+
+    out[(n*pwidthheight+xypad)*channels + ch] = value;
+}
+}
+using namespace blob_rearrange_kernel2_internal;
+
+// == Correlation Kernel
+namespace CorrelateData_internal
+{
+template <class T>
+__global__ void CorrelateData_1D(const int nthreads, int num, int topwidth, int topheight, int topchannels, int topcount,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int kernel_size, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int bottomchannels,
+  const T *bottom0, const T *bottom1, T *top)
+{
+  extern __shared__ char patch_data_char[];
+
+  T *patch_data = (T *)patch_data_char;
+
+    // First (upper left) position of kernel upper-left corner in current center position of neighborhood in image 1
+  int x1 = blockIdx.x*stride1 + max_displacement;
+  int y1 = blockIdx.y*stride1;
+  int item = blockIdx.z;
+  int ch_off = threadIdx.x;
+
+  // Load 3D patch into shared shared memory
+  for(int j = 0; j < kernel_size; j++) { // HEIGHT
+    for(int i = 0; i < kernel_size; i++) { // WIDTH
+      int ji_off = ((j * kernel_size) + i) * bottomchannels;
+      for(int ch = ch_off; ch < bottomchannels; ch += (WARPS_PER_BLOCK*THREADS_PER_WARP)) { // CHANNELS
+          int idx1 = ((item * bottomheight + y1+j) * bottomwidth + x1+i) * bottomchannels + ch;
+          int idxPatchData = ji_off + ch;
+          patch_data[idxPatchData] = bottom0[idx1];
+      }
+    }
+  }
+
+  __syncthreads();
+
+  __shared__ T sum[WARPS_PER_BLOCK*THREADS_PER_WARP];
+
+  // Compute correlation
+  for(int top_channel = 0; top_channel < topchannels; top_channel++) {
+    sum[ch_off] = 0;
+
+    int s2o = (top_channel % neighborhood_grid_width + x_shift) * stride2;
+
+    for(int j = 0; j < kernel_size; j++) { // HEIGHT
+      for(int i = 0; i < kernel_size; i++) { // WIDTH
+        int ji_off = ((j * kernel_size) + i) * bottomchannels;
+        for(int ch = ch_off; ch < bottomchannels; ch += (WARPS_PER_BLOCK*THREADS_PER_WARP)) { // CHANNELS
+          int x2 = x1 + s2o;
+
+          int idxPatchData = ji_off + ch;
+          int idx2 = ((item * bottomheight + y1+j) * bottomwidth + x2+i) * bottomchannels + ch;
+
+          sum[ch_off] += patch_data[idxPatchData] * bottom1[idx2];
+        }
+      }
+    }
+
+    __syncthreads();
+
+    if(ch_off == 0) {
+        T total_sum = 0;
+        for(int idx = 0; idx < WARPS_PER_BLOCK*THREADS_PER_WARP; idx++) {
+            total_sum += sum[idx];
+        }
+        const int sumelems = kernel_size*kernel_size*bottomchannels;
+        const int index = ((top_channel*topheight + blockIdx.y)*topwidth)+blockIdx.x;
+        top[index + item*topcount] = total_sum / (float)sumelems;
+    }
+  }
+
+
+  // Aggregate
+}
+}
+using namespace CorrelateData_internal;
+
+// == Correlation Kernel Subtraction
+namespace CorrelateDataSubtract_internal
+{
+template <class T>
+__global__ void CorrelateDataSubtract_1D(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels, int topcount,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int bottomchannels,
+  const T *bottom0, const T *bottom1, T *top)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int x = index % topwidth; //w-pos
+    int y = (index / topwidth) % topheight; //h-pos
+    int c = (index / topwidth / topheight) % topchannels; //channels
+
+    // Offset of patch in image 2
+    int s2o = (c % neighborhood_grid_width + x_shift) * stride2;
+
+    // First (upper left) position of kernel center in current neighborhood in image 1
+    int x1 = x*stride1 + kernel_radius + max_displacement;
+    int y1 = y*stride1 + kernel_radius + 0;
+
+    // Iterate through 3D patch
+    T sum = 0;
+    for(int j = -kernel_radius; j <= kernel_radius; j++) { // HEIGHT
+      for(int i = -kernel_radius; i <= kernel_radius; i++) { // WIDTH
+        for(int l = 0; l < bottomchannels; l++) { // CHANNELS
+          // Calculate position in image 2
+          int x2 = x1 + s2o;
+          int y2 = y1 ;
+
+          // Indices in bottom data: (CH=l,W=x2,H=y2,N)
+          int idx1 = ((item * bottomheight + y1+j) * bottomwidth + x1+i) * bottomchannels + l;
+          int idx2 = ((item * bottomheight + y2+j) * bottomwidth + x2+i) * bottomchannels + l;
+
+          // Do the correlation:
+          sum += fabsf(bottom0[idx1] - bottom1[idx2]);
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    top[index + item*topcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataSubtract_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 0)
+namespace CorrelateDataBackward0_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward0_1D(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  T *bottom0diff, const T *bottom1, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int n = index % bottomchannels; //channels
+    int l = (index / bottomchannels) % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomchannels / bottomwidth) % bottomheight; //h-pos
+
+    //Get X,Y ranges and clamp
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+    int xmin = (l - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+    int ymin = (m - 2*kernel_radius - 0 + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+
+    // Same here:
+    int xmax = (l - max_displacement + round_off_s1) / stride1 - round_off; // floor (l - max_displacement) / stride1
+    int ymax = (m - 0 + round_off_s1) / stride1 - round_off; // floor (m - max_displacement) / stride1
+
+
+    T sum = 0;
+    if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+    {
+        xmin = max(0,xmin);
+        xmax = min(topwidth-1,xmax);
+
+        ymin = max(0,ymin);
+        ymax = min(topheight-1,ymax);
+
+         {
+          for(int o = x_shift; o < x_shift + neighborhood_grid_width; o++) {
+
+            // Get bottom1 data:
+            int s2o = stride2 * o;
+            int idxbot1 = ((item * pbottomheight + m) * pbottomwidth + (l+s2o)) * bottomchannels + n;
+            T bot1tmp = bottom1[idxbot1]; // bottom1[l+s2o,m+s2p,n]
+
+            // Index offset for topdiff in following loops:
+			int op = (o-x_shift);
+            int idxopoffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxopoffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * bot1tmp;
+              }
+            }
+          }
+        }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+	const int bot0index = ((n * bottomheight) + m) * bottomwidth + (l-pad_size);
+    bottom0diff[bot0index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward0_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 1)
+namespace CorrelateDataBackward1_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward1_1D(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  const T *bottom0, T *bottom1diff, const T *topdiff)
+{
+
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    //int l = index % bottomwidth + pad_size; //w-pos
+    //int m = (index / bottomwidth) % bottomheight + pad_size; //h-pos
+    //int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+    int n = index % bottomchannels; //channels
+    int l = (index / bottomchannels) % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomchannels / bottomwidth) % bottomheight; //h-pos
+
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    T sum = 0;
+    {
+      for(int o = x_shift; o < x_shift+neighborhood_grid_width; o++) {
+
+        int s2o = stride2 * o;
+
+        //Get X,Y ranges and clamp
+        // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+        int xmin = (l - 2*kernel_radius - max_displacement - s2o + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+        int ymin = (m - 2*kernel_radius - 0 - 0 + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+
+        // Same here:
+        int xmax = (l - max_displacement - s2o + round_off_s1) / stride1 - round_off; // floor (l - max_displacement - s2o) / stride1
+        int ymax = (m - 0 - 0 + round_off_s1) / stride1 - round_off; // floor (m - max_displacement - s2p) / stride1
+
+        if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+        {
+            xmin = max(0,xmin);
+            xmax = min(topwidth-1,xmax);
+
+            ymin = max(0,ymin);
+            ymax = min(topheight-1,ymax);
+
+            // Get bottom0 data:
+            int idxbot0 = ((item * pbottomheight + m) * pbottomwidth + (l-s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot0]; // bottom1[l+s2o,m+s2p,n]
+
+            // Index offset for topdiff in following loops:
+            int op = (o-x_shift); //* neighborhood_grid_width + (o+neighborhood_grid_radius); // index [o,p]
+            int idxOpOffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxOpOffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * bot0tmp;
+              }
+            }
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+		const int bot1index = ((n * bottomheight) + m) * bottomwidth + (l-pad_size);
+		bottom1diff[bot1index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward1_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 0)
+namespace CorrelateDataBackward0Subtract_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward0Subtract_1D(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  T *bottom0diff, const T *bottom0, const T *bottom1, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int l = index % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomwidth) % bottomheight; //h-pos
+    int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+
+    //Get X,Y ranges and clamp
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+    int xmin = (l - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+    int ymin = (m - 2*kernel_radius - 0 + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+
+    // Same here:
+    int xmax = (l - max_displacement + round_off_s1) / stride1 - round_off; // floor (l - max_displacement) / stride1
+    int ymax = (m - 0 + round_off_s1) / stride1 - round_off; // floor (m - max_displacement) / stride1
+
+
+    T sum = 0;
+    if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+    {
+        xmin = max(0,xmin);
+        xmax = min(topwidth-1,xmax);
+
+        ymin = max(0,ymin);
+        ymax = min(topheight-1,ymax);
+
+        {
+		  for(int o = x_shift; o < x_shift + neighborhood_grid_width; o++){
+
+            // Get bottom1 data:
+            int s2o = stride2 * o;
+            int idxbot = ((item * pbottomheight + m) * pbottomwidth + (l+s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot]; // bottom0[l+s2o,m+s2p,n]
+            T bot1tmp = bottom1[idxbot]; // bottom1[l+s2o,m+s2p,n]
+            T sign = (bot0tmp >= bot1tmp) ? T(1.0) : T(-1.0);
+
+            // Index offset for topdiff in following loops:
+			int op = (o-x_shift);
+            int idxopoffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxopoffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * sign;
+              }
+            }
+          }
+        }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    bottom0diff[index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward0Subtract_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 1)
+namespace CorrelateDataBackward1Subtract_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward1Subtract_1D(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int x_shift, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  const T *bottom0, const T *bottom1, T *bottom1diff, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int l = index % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomwidth) % bottomheight; //h-pos
+    int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    T sum = 0;
+    {
+      for(int o = x_shift; o < x_shift + neighborhood_grid_width; o++){
+
+        int s2o = stride2 * o;
+
+        //Get X,Y ranges and clamp
+        // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+        int xmin = (l - 2*kernel_radius - max_displacement - s2o + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+        int ymin = (m - 2*kernel_radius - 0 - 0 + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+
+        // Same here:
+        int xmax = (l - max_displacement - s2o + round_off_s1) / stride1 - round_off; // floor (l - max_displacement - s2o) / stride1
+        int ymax = (m -0 - 0  + round_off_s1) / stride1 - round_off; // floor (m - max_displacement - s2p) / stride1
+
+        if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+        {
+            xmin = max(0,xmin);
+            xmax = min(topwidth-1,xmax);
+
+            ymin = max(0,ymin);
+            ymax = min(topheight-1,ymax);
+
+            // Get bottom0 data:
+            int idxbot = ((item * pbottomheight + m) * pbottomwidth + (l-s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot]; // bottom0[l+s2o,m+s2p,n]
+            T bot1tmp = bottom1[idxbot]; // bottom1[l+s2o,m+s2p,n]
+            T sign = (bot0tmp >= bot1tmp) ? T(-1.0) : T(1.0);
+
+            // Index offset for topdiff in following loops:
+			int op = (o-x_shift); // index [o,p]
+            int idxOpOffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxOpOffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * sign;
+              }
+            }
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    bottom1diff[index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward1Subtract_internal;
+
+template <class T>
+class Correlation1DOp_GPU : public OpKernel
+{
+public:
+  explicit Correlation1DOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction)
+  {
+    std::string corr_type_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("corr_type", &corr_type_str));
+    if( corr_type_str == "mult" )
+      corr_type_ = MULT;
+    else
+      corr_type_ = SUBT;
+
+    // Get attributes
+    OP_REQUIRES_OK(construction, construction->GetAttr("kernel_size", &kernel_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("max_displacement", &max_displacement_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("pad_size", &pad_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride1", &stride1_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride2", &stride2_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("do_abs", &do_abs_));
+	OP_REQUIRES_OK(construction, construction->GetAttr("single_dir", &single_dir_));
+
+    OP_REQUIRES(construction, kernel_size_ % 2 != 0, errors::InvalidArgument("Correlation cannot be done with even kernel_size"));
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+    // Get the inputs
+    const Tensor& input1_tensor = context->input(0);
+    const Tensor& input2_tensor = context->input(1);
+
+    // Get the shapes
+    const TensorShape input1_shape(input1_tensor.shape());
+    const TensorShape input2_shape(input2_tensor.shape());
+
+    int num      = input1_shape.dim_size(0);
+    int channels = input1_shape.dim_size(1);
+    int height   = input1_shape.dim_size(2);
+    int width    = input1_shape.dim_size(3);
+
+    int paddedbottomheight = height;
+    int paddedbottomwidth = width+2*pad_size_;
+	int neighborhood_grid_width, neighborhood_grid_radius;
+    int rsize = num*paddedbottomheight*paddedbottomwidth*channels;
+
+    // Size computation
+    kernel_radius_ = (kernel_size_ - 1) / 2; //size of unreachable border region (on each side)
+    border_size_ = max_displacement_ + kernel_radius_; //size of unreachable border region (on each side)
+
+    top_width_ = ceil((float)(paddedbottomwidth - border_size_*2) / (float)stride1_);
+    top_height_ = ceil((float)(paddedbottomheight - kernel_radius_*2) / (float)stride1_);
+
+    OP_REQUIRES(context, top_width_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+    OP_REQUIRES(context, top_height_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+
+    // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+    neighborhood_grid_radius_ = max_displacement_ / stride2_;
+	if(single_dir_ !=0)
+    	neighborhood_grid_width_ = neighborhood_grid_radius_ + 1;
+	else
+    	neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;
+
+
+    // Top Channels amount to displacement combinations in X and Y direction:
+    top_channels_ = neighborhood_grid_width_ ;
+
+    TensorShape output_shape;
+    output_shape.AddDim(num);
+    output_shape.AddDim(top_channels_);
+    output_shape.AddDim(top_height_);
+    output_shape.AddDim(top_width_);
+
+    // Allocate memory for the output image
+    Tensor* output_tensor = 0;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output_tensor));
+
+    auto device = context->eigen_gpu_device();
+
+    // rbots (These are the blobs that store the padded and dimension rearranged data
+    TensorShape rbot_shape;
+    rbot_shape.AddDim(num);
+    rbot_shape.AddDim(paddedbottomheight);
+    rbot_shape.AddDim(paddedbottomwidth);
+    rbot_shape.AddDim(channels);
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot1_gpu_tensor));
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot2_gpu_tensor));
+
+    // Prepare for correlation
+    auto input1 = input1_tensor.flat<T>();
+    auto input2 = input2_tensor.flat<T>();
+    auto output = output_tensor->flat<T>();
+
+    auto rbot1 = rbot1_gpu_tensor.flat<T>();
+    auto rbot2 = rbot2_gpu_tensor.flat<T>();
+
+	int x_shift = - neighborhood_grid_radius_;
+    if(single_dir_ == -1) { // to the left
+      x_shift = -neighborhood_grid_width_;
+    } else if(single_dir_ == 1) { // to the right
+      x_shift = 0;
+    }
+
+    Correlation_GPU(device.stream(), output.data(), rbot1.data(), rbot2.data(), input1.data(), input2.data(), num, channels, height, width, rsize, x_shift);
+  }
+
+  void Correlation_GPU( const cudaStream_t& stream,
+                        T*                  output,
+                        T*                  rbot1,
+                        T*                  rbot2,
+                        const T*            input1,
+                        const T*            input2,
+                        const int           bnum,
+                        const int           bchannels,
+                        const int           bheight,
+                        const int           bwidth,
+                        const int           rsize,
+						const int 			x_shift
+                      )
+  {
+    const int bwidthheight = bwidth * bheight;
+
+    const int topcount = top_width_ * top_height_ * top_channels_;
+
+    dim3 threadsPerBlock(THREADS_PER_WARP * WARPS_PER_BLOCK);
+
+    cudaMemset(rbot1, 0, rsize*sizeof(T));
+    cudaMemset(rbot2, 0, rsize*sizeof(T));
+
+    int threads_per_block=16;
+    dim3 totalBlocksRearr((bwidthheight-1)/threads_per_block+1, bchannels, bnum);
+    const int pwidthheight = (bwidth + 2 * pad_size_) * (bheight);
+
+    blob_rearrange_kernel2_1D<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input1,rbot1,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    blob_rearrange_kernel2_1D<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input2,rbot2,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    const int num = bnum;
+    const int channels = bchannels;
+    const int height = bheight;
+    const int width = bwidth + 2*pad_size_;
+
+    const int shared_memory_per_block = (kernel_size_*kernel_size_)*bchannels;
+
+    if(corr_type_ == MULT) {
+        // CorrelationLayer
+        int topThreadCount = topcount;
+
+        dim3 totalBlocksCorr(top_width_, top_height_, num);
+
+
+        CorrelateData_1D<T><<<totalBlocksCorr, threadsPerBlock, shared_memory_per_block * sizeof(T), stream>>>(
+            topThreadCount,
+            num, top_width_, top_height_, top_channels_, topcount,
+            max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_, kernel_size_,
+            stride1_, stride2_,
+            width, height, channels,
+            rbot1, rbot2, output
+            );
+
+        CHECK_CUDA_ERROR;
+
+    } else if(corr_type_ == SUBT) {
+        // CorrelationLayer
+        for(int n = 0; n < num; n++) {
+
+            int topThreadCount = topcount;
+
+            CorrelateDataSubtract_1D<T><<<LMBOPS_GET_BLOCKS(topThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+                topThreadCount,
+                num, n, top_width_, top_height_, top_channels_, topcount,
+                max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_,
+                stride1_, stride2_,
+                width, height, channels,
+                rbot1, rbot2, output
+                );
+
+
+            CHECK_CUDA_ERROR;
+        }
+    }
+  }
+private:
+  int kernel_size_;
+
+  int stride1_;
+  int stride2_;
+  int max_displacement_;
+
+  int pad_size_;
+
+  int num_;
+  int top_height_, top_width_;
+  int top_channels_;
+
+  // Correlation specific
+  bool do_abs_;
+
+  enum CorrType {MULT = 1, SUBT = 2};
+  CorrType corr_type_;
+
+  Tensor rbot1_gpu_tensor;
+  Tensor rbot2_gpu_tensor;
+
+  // Computed
+  int kernel_radius_;
+  int border_size_;
+  int neighborhood_grid_radius_, neighborhood_grid_width_;
+  int single_dir_;
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("Correlation1D")                                                       \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    Correlation1DOp_GPU<type>);
+REG_KB(float)
+#undef REG_KB
+
+
+template <class T>
+class Correlation1DGradOp_GPU : public OpKernel
+{
+public:
+  explicit Correlation1DGradOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction)
+  {
+    std::string corr_type_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("corr_type", &corr_type_str));
+    if( corr_type_str == "mult" )
+      corr_type_ = MULT;
+    else
+      corr_type_ = SUBT;
+
+    // Get attributes
+    OP_REQUIRES_OK(construction, construction->GetAttr("kernel_size", &kernel_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("max_displacement", &max_displacement_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("pad_size", &pad_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride1", &stride1_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride2", &stride2_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("do_abs", &do_abs_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("single_dir", &single_dir_));
+
+    OP_REQUIRES(construction, kernel_size_ % 2 != 0, errors::InvalidArgument("Correlation cannot be done with even kernel_size"));
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+    // Get the inputs
+    const Tensor& input1_tensor   = context->input(0);
+    const Tensor& input2_tensor   = context->input(1);
+    const Tensor& gradient_tensor = context->input(2);
+
+    // Get the shapes
+    const TensorShape input1_shape(input1_tensor.shape());
+    const TensorShape input2_shape(input2_tensor.shape());
+
+    int num      = input1_shape.dim_size(0);
+    int channels = input1_shape.dim_size(1);
+    int height   = input1_shape.dim_size(2);
+    int width    = input1_shape.dim_size(3);
+
+    int paddedbottomheight = height;
+    int paddedbottomwidth = width+2*pad_size_;
+
+    int rsize = num*paddedbottomheight*paddedbottomwidth*channels;
+
+    // Size computation
+    kernel_radius_ = (kernel_size_ - 1) / 2; //size of unreachable border region (on each side)
+    border_size_ = max_displacement_ + kernel_radius_; //size of unreachable border region (on each side)
+
+    top_width_ = ceil((float)(paddedbottomwidth - border_size_*2) / (float)stride1_);
+    top_height_ = ceil((float)(paddedbottomheight - kernel_radius_*2) / (float)stride1_);
+
+    OP_REQUIRES(context, top_width_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+    OP_REQUIRES(context, top_height_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+
+    // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+    neighborhood_grid_radius_ = max_displacement_ / stride2_;
+ 	if(single_dir_ != 0) {
+		neighborhood_grid_width_ = neighborhood_grid_radius_ + 1;
+  	} else {
+    	neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;
+  	}
+
+    // Top Channels amount to displacement combinations in X and Y direction:
+    top_channels_ = neighborhood_grid_width_ ;
+
+    // Allocate the memory for the output
+    Tensor* input1_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, input1_shape, &input1_grad_tensor));
+    Tensor* input2_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(1, input2_shape, &input2_grad_tensor));
+
+    auto device = context->eigen_gpu_device();
+
+    // rbots (These are the blobs that store the padded and dimension rearranged data
+    TensorShape rbot_shape;
+    rbot_shape.AddDim(num);
+    rbot_shape.AddDim(paddedbottomheight);
+    rbot_shape.AddDim(paddedbottomwidth);
+    rbot_shape.AddDim(channels);
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot1_gpu_tensor));
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot2_gpu_tensor));
+
+    // Prepare for gradient computation
+    auto input1      = input1_tensor.flat<T>();
+    auto input2      = input2_tensor.flat<T>();
+    auto gradient    = gradient_tensor.flat<T>();
+    auto input1_grad = input1_grad_tensor->flat<T>();
+    auto input2_grad = input2_grad_tensor->flat<T>();
+
+    auto rbot1 = rbot1_gpu_tensor.flat<T>();
+    auto rbot2 = rbot2_gpu_tensor.flat<T>();
+
+	int x_shift = - neighborhood_grid_radius_ ;
+
+    if(single_dir_ == -1) { // to the left
+      x_shift = -neighborhood_grid_width_;
+    } else if(single_dir_ == 1) { // to the right
+      x_shift = 0;
+    }
+
+    CorrelationGrad_GPU(device.stream(), input1_grad.data(), input2_grad.data(), rbot1.data(), rbot2.data(), input1.data(), input2.data(), gradient.data(), num, channels, height, width, paddedbottomheight, paddedbottomwidth, rsize, x_shift);
+
+  	}
+
+
+  void CorrelationGrad_GPU( const cudaStream_t& stream,
+                            T*                  input1_grad,
+                            T*                  input2_grad,
+                            T*                  rbot1,
+                            T*                  rbot2,
+                            const T*            input1,
+                            const T*            input2,
+                            const T*            gradient,
+                            const int           bnum,
+                            const int           bchannels,
+                            const int           bheight,
+                            const int           bwidth,
+                            const int           paddedheight,
+                            const int           paddedwidth,
+                            const int           rsize,
+							const int 			x_shift
+                          )
+  {
+    const int bwidthheight = bwidth * bheight;
+
+    cudaMemset(rbot1, 0, rsize*sizeof(T));
+    cudaMemset(rbot2, 0, rsize*sizeof(T));
+
+    int threads_per_block=16;
+    dim3 totalBlocksRearr((bwidthheight-1)/threads_per_block+1, bchannels, bnum);
+    const int pwidthheight = (bwidth + 2 * pad_size_) * (bheight);
+
+    blob_rearrange_kernel2_1D<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input1,rbot1,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+    CHECK_CUDA_ERROR;
+    blob_rearrange_kernel2_1D<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input2,rbot2,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+    CHECK_CUDA_ERROR;
+
+    const int num = bnum;
+    const int channels = bchannels;
+    const int height = bheight;
+    const int width = bwidth;
+
+    const int bottomcount = channels * height * width;
+
+    int botThreadCount = bottomcount;
+
+    // CorrelationLayerBackward
+    if(corr_type_ == MULT) {
+
+        // == Run kernel Backward 0
+        dim3 totalBlocksBackward0(width, height, channels * num); //First dim is fastest
+        dim3 threadsPerBlockBackward0(THREADS_PER_WARP * WARPS_PER_BLOCK);
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward0_1D<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            input1_grad, rbot2, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+        // == Run kernel Backward 1
+        for(int n = 0; n < num; n++) {
+        CorrelateDataBackward1_1D<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            rbot1, input2_grad, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+    } else if(corr_type_ == SUBT) {
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward0Subtract_1D<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            input1_grad, rbot1, rbot2, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward1Subtract_1D<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, x_shift, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            rbot1, rbot2, input2_grad, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+    }
+  }
+private:
+  int kernel_size_;
+
+  int stride1_;
+  int stride2_;
+  int max_displacement_;
+
+  int pad_size_;
+
+  int num_;
+  int top_height_, top_width_;
+  int top_channels_;
+
+  // Correlation specific
+  bool do_abs_;
+
+  enum CorrType {MULT = 1, SUBT = 2};
+  CorrType corr_type_;
+
+  Tensor rbot1_gpu_tensor;
+  Tensor rbot2_gpu_tensor;
+
+  // Computed
+  int kernel_radius_;
+  int border_size_;
+  int neighborhood_grid_radius_, neighborhood_grid_width_;
+  int single_dir_;
+
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("Correlation1DGrad")                                                   \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    Correlation1DGradOp_GPU<type>);
+REG_KB(float)
+#undef REG_KB

--- a/src/correlation_cuda.cu
+++ b/src/correlation_cuda.cu
@@ -1,0 +1,910 @@
+//
+//  lmbspecialops - a collection of tensorflow ops
+//  Copyright (C) 2017  Oezguen Cicek, Eddy Ilg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#define EIGEN_USE_GPU
+#include "config.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "helper.h"
+#include "cuda_helper.h"
+#include "Eigen/Core"
+
+#define ROUND_OFF 50000
+
+#define WARPS_PER_BLOCK 1
+#define THREADS_PER_WARP 32
+
+using namespace tensorflow;
+
+// == Dimension rearrangement Kernel
+namespace blob_rearrange_kernel2_internal
+{
+template <class T>
+__global__ void blob_rearrange_kernel2(const T* in, T* out, int num, int channels, int width, int height, int widthheight, int padding, int pwidthheight)
+{
+    int xy = blockIdx.x*blockDim.x + threadIdx.x;
+    if(xy>=widthheight)
+        return;
+
+    int ch = blockIdx.y;
+    int n  = blockIdx.z;
+
+    T value=in[(n*channels+ch)*widthheight+xy];
+
+    __syncthreads();
+
+    int xpad  = (xy % width + padding);
+    int ypad  = (xy / width + padding);
+    int xypad = ypad * (width+2*padding) + xpad;
+
+    out[(n*pwidthheight+xypad)*channels + ch] = value;
+}
+}
+using namespace blob_rearrange_kernel2_internal;
+
+// == Correlation Kernel
+namespace CorrelateData_internal
+{
+template <class T>
+__global__ void CorrelateData(const int nthreads, int num, int topwidth, int topheight, int topchannels, int topcount,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int kernel_size, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int bottomchannels,
+  const T *bottom0, const T *bottom1, T *top)
+{
+  extern __shared__ char patch_data_char[];
+
+  T *patch_data = (T *)patch_data_char;
+
+    // First (upper left) position of kernel upper-left corner in current center position of neighborhood in image 1
+  int x1 = blockIdx.x*stride1 + max_displacement;
+  int y1 = blockIdx.y*stride1 + max_displacement;
+  int item = blockIdx.z;
+  int ch_off = threadIdx.x;
+
+  // Load 3D patch into shared shared memory
+  for(int j = 0; j < kernel_size; j++) { // HEIGHT
+    for(int i = 0; i < kernel_size; i++) { // WIDTH
+      int ji_off = ((j * kernel_size) + i) * bottomchannels;
+      for(int ch = ch_off; ch < bottomchannels; ch += (WARPS_PER_BLOCK*THREADS_PER_WARP)) { // CHANNELS
+          int idx1 = ((item * bottomheight + y1+j) * bottomwidth + x1+i) * bottomchannels + ch;
+          int idxPatchData = ji_off + ch;
+          patch_data[idxPatchData] = bottom0[idx1];
+      }
+    }
+  }
+
+  __syncthreads();
+
+  __shared__ T sum[WARPS_PER_BLOCK*THREADS_PER_WARP];
+
+  // Compute correlation
+  for(int top_channel = 0; top_channel < topchannels; top_channel++) {
+    sum[ch_off] = 0;
+
+    int s2o = (top_channel % neighborhood_grid_width - neighborhood_grid_radius) * stride2;
+    int s2p = (top_channel / neighborhood_grid_width - neighborhood_grid_radius) * stride2;
+
+    for(int j = 0; j < kernel_size; j++) { // HEIGHT
+      for(int i = 0; i < kernel_size; i++) { // WIDTH
+        int ji_off = ((j * kernel_size) + i) * bottomchannels;
+        for(int ch = ch_off; ch < bottomchannels; ch += (WARPS_PER_BLOCK*THREADS_PER_WARP)) { // CHANNELS
+          int x2 = x1 + s2o;
+          int y2 = y1 + s2p;
+
+          int idxPatchData = ji_off + ch;
+          int idx2 = ((item * bottomheight + y2+j) * bottomwidth + x2+i) * bottomchannels + ch;
+
+          sum[ch_off] += patch_data[idxPatchData] * bottom1[idx2];
+        }
+      }
+    }
+
+    __syncthreads();
+
+    if(ch_off == 0) {
+        T total_sum = 0;
+        for(int idx = 0; idx < WARPS_PER_BLOCK*THREADS_PER_WARP; idx++) {
+            total_sum += sum[idx];
+        }
+        const int sumelems = kernel_size*kernel_size*bottomchannels;
+        const int index = ((top_channel*topheight + blockIdx.y)*topwidth)+blockIdx.x;
+        top[index + item*topcount] = total_sum / (float)sumelems;
+    }
+  }
+
+
+  // Aggregate
+}
+}
+using namespace CorrelateData_internal;
+
+// == Correlation Kernel Subtraction
+namespace CorrelateDataSubtract_internal
+{
+template <class T>
+__global__ void CorrelateDataSubtract(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels, int topcount,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int bottomchannels,
+  const T *bottom0, const T *bottom1, T *top)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int x = index % topwidth; //w-pos
+    int y = (index / topwidth) % topheight; //h-pos
+    int c = (index / topwidth / topheight) % topchannels; //channels
+
+    // Offset of patch in image 2
+    int s2o = (c % neighborhood_grid_width - neighborhood_grid_radius) * stride2;
+    int s2p = (c / neighborhood_grid_width - neighborhood_grid_radius) * stride2;
+
+    // First (upper left) position of kernel center in current neighborhood in image 1
+    int x1 = x*stride1 + kernel_radius + max_displacement;
+    int y1 = y*stride1 + kernel_radius + max_displacement;
+
+    // Iterate through 3D patch
+    T sum = 0;
+    for(int j = -kernel_radius; j <= kernel_radius; j++) { // HEIGHT
+      for(int i = -kernel_radius; i <= kernel_radius; i++) { // WIDTH
+        for(int l = 0; l < bottomchannels; l++) { // CHANNELS
+          // Calculate position in image 2
+          int x2 = x1 + s2o;
+          int y2 = y1 + s2p;
+
+          // Indices in bottom data: (CH=l,W=x2,H=y2,N)
+          int idx1 = ((item * bottomheight + y1+j) * bottomwidth + x1+i) * bottomchannels + l;
+          int idx2 = ((item * bottomheight + y2+j) * bottomwidth + x2+i) * bottomchannels + l;
+
+          // Do the correlation:
+          sum += fabsf(bottom0[idx1] - bottom1[idx2]);
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    top[index + item*topcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataSubtract_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 0)
+namespace CorrelateDataBackward0_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward0(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  T *bottom0diff, const T *bottom1, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int n = index % bottomchannels; //channels
+    int l = (index / bottomchannels) % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomchannels / bottomwidth) % bottomheight + pad_size; //h-pos
+
+    //Get X,Y ranges and clamp
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+    int xmin = (l - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+    int ymin = (m - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+
+    // Same here:
+    int xmax = (l - max_displacement + round_off_s1) / stride1 - round_off; // floor (l - max_displacement) / stride1
+    int ymax = (m - max_displacement + round_off_s1) / stride1 - round_off; // floor (m - max_displacement) / stride1
+
+
+    T sum = 0;
+    if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+    {
+        xmin = max(0,xmin);
+        xmax = min(topwidth-1,xmax);
+
+        ymin = max(0,ymin);
+        ymax = min(topheight-1,ymax);
+
+        for(int p = -neighborhood_grid_radius; p <= neighborhood_grid_radius; p++) {
+          for(int o = -neighborhood_grid_radius; o <= neighborhood_grid_radius; o++) {
+
+            // Get bottom1 data:
+            int s2o = stride2 * o;
+            int s2p = stride2 * p;
+            int idxbot1 = ((item * pbottomheight + (m+s2p)) * pbottomwidth + (l+s2o)) * bottomchannels + n;
+            T bot1tmp = bottom1[idxbot1]; // bottom1[l+s2o,m+s2p,n]
+
+            // Index offset for topdiff in following loops:
+            int op = (p+neighborhood_grid_radius) * neighborhood_grid_width + (o+neighborhood_grid_radius); // index [o,p]
+            int idxopoffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxopoffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * bot1tmp;
+              }
+            }
+          }
+        }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+		const int bot0index = ((n * bottomheight) + (m-pad_size)) * bottomwidth + (l-pad_size);
+    bottom0diff[bot0index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward0_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 1)
+namespace CorrelateDataBackward1_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward1(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  const T *bottom0, T *bottom1diff, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    //int l = index % bottomwidth + pad_size; //w-pos
+    //int m = (index / bottomwidth) % bottomheight + pad_size; //h-pos
+    //int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+    int n = index % bottomchannels; //channels
+    int l = (index / bottomchannels) % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomchannels / bottomwidth) % bottomheight + pad_size; //h-pos
+
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    T sum = 0;
+    for(int p = -neighborhood_grid_radius; p <= neighborhood_grid_radius; p++) {
+      for(int o = -neighborhood_grid_radius; o <= neighborhood_grid_radius; o++) {
+
+        int s2o = stride2 * o;
+        int s2p = stride2 * p;
+
+        //Get X,Y ranges and clamp
+        // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+        int xmin = (l - 2*kernel_radius - max_displacement - s2o + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+        int ymin = (m - 2*kernel_radius - max_displacement - s2p + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+
+        // Same here:
+        int xmax = (l - max_displacement - s2o + round_off_s1) / stride1 - round_off; // floor (l - max_displacement - s2o) / stride1
+        int ymax = (m - max_displacement - s2p + round_off_s1) / stride1 - round_off; // floor (m - max_displacement - s2p) / stride1
+
+        if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+        {
+            xmin = max(0,xmin);
+            xmax = min(topwidth-1,xmax);
+
+            ymin = max(0,ymin);
+            ymax = min(topheight-1,ymax);
+
+            // Get bottom0 data:
+            int idxbot0 = ((item * pbottomheight + (m-s2p)) * pbottomwidth + (l-s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot0]; // bottom1[l+s2o,m+s2p,n]
+
+            // Index offset for topdiff in following loops:
+            int op = (p+neighborhood_grid_radius) * neighborhood_grid_width + (o+neighborhood_grid_radius); // index [o,p]
+            int idxOpOffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxOpOffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * bot0tmp;
+              }
+            }
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+		const int bot1index = ((n * bottomheight) + (m-pad_size)) * bottomwidth + (l-pad_size);
+		bottom1diff[bot1index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward1_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 0)
+namespace CorrelateDataBackward0Subtract_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward0Subtract(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  T *bottom0diff, const T *bottom0, const T *bottom1, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int l = index % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomwidth) % bottomheight + pad_size; //h-pos
+    int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+
+    //Get X,Y ranges and clamp
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+    int xmin = (l - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+    int ymin = (m - 2*kernel_radius - max_displacement + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement) / stride1
+
+    // Same here:
+    int xmax = (l - max_displacement + round_off_s1) / stride1 - round_off; // floor (l - max_displacement) / stride1
+    int ymax = (m - max_displacement + round_off_s1) / stride1 - round_off; // floor (m - max_displacement) / stride1
+
+
+    T sum = 0;
+    if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+    {
+        xmin = max(0,xmin);
+        xmax = min(topwidth-1,xmax);
+
+        ymin = max(0,ymin);
+        ymax = min(topheight-1,ymax);
+
+        for(int p = -neighborhood_grid_radius; p <= neighborhood_grid_radius; p++) {
+          for(int o = -neighborhood_grid_radius; o <= neighborhood_grid_radius; o++) {
+
+            // Get bottom1 data:
+            int s2o = stride2 * o;
+            int s2p = stride2 * p;
+            int idxbot = ((item * pbottomheight + (m+s2p)) * pbottomwidth + (l+s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot]; // bottom0[l+s2o,m+s2p,n]
+            T bot1tmp = bottom1[idxbot]; // bottom1[l+s2o,m+s2p,n]
+            T sign = (bot0tmp >= bot1tmp) ? T(1.0) : T(-1.0);
+
+            // Index offset for topdiff in following loops:
+            int op = (p+neighborhood_grid_radius) * neighborhood_grid_width + (o+neighborhood_grid_radius); // index [o,p]
+            int idxopoffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxopoffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * sign;
+              }
+            }
+          }
+        }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    bottom0diff[index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward0Subtract_internal;
+
+// == Correlation Backward Pass Kernel (For Blob 1)
+namespace CorrelateDataBackward1Subtract_internal
+{
+template <class T>
+__global__ void CorrelateDataBackward1Subtract(const int nthreads, int num, int item, int topwidth, int topheight, int topchannels,
+  int max_displacement, int neighborhood_grid_radius, int neighborhood_grid_width, int kernel_radius, int stride1, int stride2,
+  int bottomwidth, int bottomheight, int pbottomwidth, int pbottomheight, int bottomchannels, int bottomcount, int pad_size,
+  const T *bottom0, const T *bottom1, T *bottom1diff, const T *topdiff)
+{
+  LMBOPS_CUDA_KERNEL_LOOP(index, nthreads) {
+    int l = index % bottomwidth + pad_size; //w-pos
+    int m = (index / bottomwidth) % bottomheight + pad_size; //h-pos
+    int n = (index / bottomwidth / bottomheight) % bottomchannels; //channels
+
+    // round_off is a trick to enable integer division with ceil, even for negative numbers
+    // We use a large offset, for the inner part not to become negative.
+    const int round_off = ROUND_OFF;
+    const int round_off_s1 = stride1 * round_off;
+
+    T sum = 0;
+    for(int p = -neighborhood_grid_radius; p <= neighborhood_grid_radius; p++) {
+      for(int o = -neighborhood_grid_radius; o <= neighborhood_grid_radius; o++) {
+
+        int s2o = stride2 * o;
+        int s2p = stride2 * p;
+
+        //Get X,Y ranges and clamp
+        // We add round_off before_s1 the int division and subtract round_off after it, to ensure the formula matches ceil behavior:
+        int xmin = (l - 2*kernel_radius - max_displacement - s2o + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+        int ymin = (m - 2*kernel_radius - max_displacement - s2p + round_off_s1 - 1) / stride1 + 1 - round_off; // ceil (l - 2*kernel_radius - max_displacement - s2o) / stride1
+
+        // Same here:
+        int xmax = (l - max_displacement - s2o + round_off_s1) / stride1 - round_off; // floor (l - max_displacement - s2o) / stride1
+        int ymax = (m - max_displacement - s2p + round_off_s1) / stride1 - round_off; // floor (m - max_displacement - s2p) / stride1
+
+        if(xmax>=0 && ymax>=0 && (xmin<=topwidth-1) && (ymin<=topheight-1))
+        {
+            xmin = max(0,xmin);
+            xmax = min(topwidth-1,xmax);
+
+            ymin = max(0,ymin);
+            ymax = min(topheight-1,ymax);
+
+            // Get bottom0 data:
+            int idxbot = ((item * pbottomheight + (m-s2p)) * pbottomwidth + (l-s2o)) * bottomchannels + n;
+            T bot0tmp = bottom0[idxbot]; // bottom0[l+s2o,m+s2p,n]
+            T bot1tmp = bottom1[idxbot]; // bottom1[l+s2o,m+s2p,n]
+            T sign = (bot0tmp >= bot1tmp) ? T(-1.0) : T(1.0);
+
+            // Index offset for topdiff in following loops:
+            int op = (p+neighborhood_grid_radius) * neighborhood_grid_width + (o+neighborhood_grid_radius); // index [o,p]
+            int idxOpOffset = (item * topchannels + op);
+
+            for(int y = ymin; y <= ymax; y++) {
+              for(int x = xmin; x <= xmax; x++) {
+                int idxtopdiff = (idxOpOffset * topheight + y) * topwidth + x; // topdiff[x,y,o,p]
+                sum += topdiff[idxtopdiff] * sign;
+              }
+            }
+        }
+      }
+    }
+    const int sumelems = (kernel_radius*2+1)*(kernel_radius*2+1)*bottomchannels;
+    bottom1diff[index + item*bottomcount] = sum / (float)sumelems;
+  }
+
+}
+}
+using namespace CorrelateDataBackward1Subtract_internal;
+
+template <class T>
+class CorrelationOp_GPU : public OpKernel
+{
+public:
+  explicit CorrelationOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction)
+  {
+    std::string corr_type_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("corr_type", &corr_type_str));
+    if( corr_type_str == "mult" )
+      corr_type_ = MULT;
+    else
+      corr_type_ = SUBT;
+
+    // Get attributes
+    OP_REQUIRES_OK(construction, construction->GetAttr("kernel_size", &kernel_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("max_displacement", &max_displacement_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("pad_size", &pad_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride1", &stride1_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride2", &stride2_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("do_abs", &do_abs_));
+
+    OP_REQUIRES(construction, kernel_size_ % 2 != 0, errors::InvalidArgument("Correlation cannot be done with even kernel_size"));
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+    // Get the inputs
+    const Tensor& input1_tensor = context->input(0);
+    const Tensor& input2_tensor = context->input(1);
+
+    // Get the shapes
+    const TensorShape input1_shape(input1_tensor.shape());
+    const TensorShape input2_shape(input2_tensor.shape());
+
+    int num      = input1_shape.dim_size(0);
+    int channels = input1_shape.dim_size(1);
+    int height   = input1_shape.dim_size(2);
+    int width    = input1_shape.dim_size(3);
+
+    int paddedbottomheight = height+2*pad_size_;
+    int paddedbottomwidth = width+2*pad_size_;
+
+    int rsize = num*paddedbottomheight*paddedbottomwidth*channels;
+
+    // Size computation
+    kernel_radius_ = (kernel_size_ - 1) / 2; //size of unreachable border region (on each side)
+    border_size_ = max_displacement_ + kernel_radius_; //size of unreachable border region (on each side)
+
+    top_width_ = ceil((float)(paddedbottomwidth - border_size_*2) / (float)stride1_);
+    top_height_ = ceil((float)(paddedbottomheight - border_size_*2) / (float)stride1_);
+
+    OP_REQUIRES(context, top_width_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+    OP_REQUIRES(context, top_height_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+
+    // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+    neighborhood_grid_radius_ = max_displacement_ / stride2_;
+    neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;
+
+    // Top Channels amount to displacement combinations in X and Y direction:
+    top_channels_ = neighborhood_grid_width_ * neighborhood_grid_width_;
+
+    TensorShape output_shape;
+    output_shape.AddDim(num);
+    output_shape.AddDim(top_channels_);
+    output_shape.AddDim(top_height_);
+    output_shape.AddDim(top_width_);
+
+    // Allocate memory for the output image
+    Tensor* output_tensor = 0;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output_tensor));
+
+    auto device = context->eigen_gpu_device();
+
+    // rbots (These are the blobs that store the padded and dimension rearranged data
+    TensorShape rbot_shape;
+    rbot_shape.AddDim(num);
+    rbot_shape.AddDim(paddedbottomheight);
+    rbot_shape.AddDim(paddedbottomwidth);
+    rbot_shape.AddDim(channels);
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot1_gpu_tensor));
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot2_gpu_tensor));
+
+    // Prepare for correlation
+    auto input1 = input1_tensor.flat<T>();
+    auto input2 = input2_tensor.flat<T>();
+    auto output = output_tensor->flat<T>();
+
+    auto rbot1 = rbot1_gpu_tensor.flat<T>();
+    auto rbot2 = rbot2_gpu_tensor.flat<T>();
+
+    Correlation_GPU(device.stream(), output.data(), rbot1.data(), rbot2.data(), input1.data(), input2.data(), num, channels, height, width, rsize);
+  }
+
+  void Correlation_GPU( const cudaStream_t& stream,
+                        T*                  output,
+                        T*                  rbot1,
+                        T*                  rbot2,
+                        const T*            input1,
+                        const T*            input2,
+                        const int           bnum,
+                        const int           bchannels,
+                        const int           bheight,
+                        const int           bwidth,
+                        const int           rsize
+                      )
+  {
+    const int bwidthheight = bwidth * bheight;
+
+    const int topcount = top_width_ * top_height_ * top_channels_;
+
+    dim3 threadsPerBlock(THREADS_PER_WARP * WARPS_PER_BLOCK);
+
+    cudaMemset(rbot1, 0, rsize*sizeof(T));
+    cudaMemset(rbot2, 0, rsize*sizeof(T));
+
+    int threads_per_block=16;
+    dim3 totalBlocksRearr((bwidthheight-1)/threads_per_block+1, bchannels, bnum);
+    const int pwidthheight = (bwidth + 2 * pad_size_) * (bheight + 2 * pad_size_);
+
+    blob_rearrange_kernel2<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input1,rbot1,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    blob_rearrange_kernel2<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input2,rbot2,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    const int num = bnum;
+    const int channels = bchannels;
+    const int height = bheight + 2*pad_size_;
+    const int width = bwidth + 2*pad_size_;
+
+    const int shared_memory_per_block = (kernel_size_*kernel_size_)*bchannels;
+
+    if(corr_type_ == MULT) {
+        // CorrelationLayer
+        int topThreadCount = topcount;
+
+        dim3 totalBlocksCorr(top_width_, top_height_, num);
+
+
+        CorrelateData<T><<<totalBlocksCorr, threadsPerBlock, shared_memory_per_block * sizeof(T), stream>>>(
+            topThreadCount,
+            num, top_width_, top_height_, top_channels_, topcount,
+            max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_, kernel_size_,
+            stride1_, stride2_,
+            width, height, channels,
+            rbot1, rbot2, output
+            );
+
+        CHECK_CUDA_ERROR;
+
+    } else if(corr_type_ == SUBT) {
+        // CorrelationLayer
+        for(int n = 0; n < num; n++) {
+
+            int topThreadCount = topcount;
+
+            CorrelateDataSubtract<T><<<LMBOPS_GET_BLOCKS(topThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+                topThreadCount,
+                num, n, top_width_, top_height_, top_channels_, topcount,
+                max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_,
+                stride1_, stride2_,
+                width, height, channels,
+                rbot1, rbot2, output
+                );
+
+
+            CHECK_CUDA_ERROR;
+        }
+    }
+  }
+private:
+  int kernel_size_;
+
+  int stride1_;
+  int stride2_;
+  int max_displacement_;
+
+  int pad_size_;
+
+  int num_;
+  int top_height_, top_width_;
+  int top_channels_;
+
+  // Correlation specific
+  bool do_abs_;
+
+  enum CorrType {MULT = 1, SUBT = 2};
+  CorrType corr_type_;
+
+  Tensor rbot1_gpu_tensor;
+  Tensor rbot2_gpu_tensor;
+
+  // Computed
+  int kernel_radius_;
+  int border_size_;
+  int neighborhood_grid_radius_, neighborhood_grid_width_;
+
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("Correlation")                                                       \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    CorrelationOp_GPU<type>);
+REG_KB(float)
+#undef REG_KB
+
+
+template <class T>
+class CorrelationGradOp_GPU : public OpKernel
+{
+public:
+  explicit CorrelationGradOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction)
+  {
+    std::string corr_type_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("corr_type", &corr_type_str));
+    if( corr_type_str == "mult" )
+      corr_type_ = MULT;
+    else
+      corr_type_ = SUBT;
+
+    // Get attributes
+    OP_REQUIRES_OK(construction, construction->GetAttr("kernel_size", &kernel_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("max_displacement", &max_displacement_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("pad_size", &pad_size_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride1", &stride1_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("stride2", &stride2_));
+    OP_REQUIRES_OK(construction, construction->GetAttr("do_abs", &do_abs_));
+
+    OP_REQUIRES(construction, kernel_size_ % 2 != 0, errors::InvalidArgument("Correlation cannot be done with even kernel_size"));
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+    // Get the inputs
+    const Tensor& input1_tensor   = context->input(0);
+    const Tensor& input2_tensor   = context->input(1);
+    const Tensor& gradient_tensor = context->input(2);
+
+    // Get the shapes
+    const TensorShape input1_shape(input1_tensor.shape());
+    const TensorShape input2_shape(input2_tensor.shape());
+
+    int num      = input1_shape.dim_size(0);
+    int channels = input1_shape.dim_size(1);
+    int height   = input1_shape.dim_size(2);
+    int width    = input1_shape.dim_size(3);
+
+    int paddedbottomheight = height+2*pad_size_;
+    int paddedbottomwidth = width+2*pad_size_;
+
+    int rsize = num*paddedbottomheight*paddedbottomwidth*channels;
+
+    // Size computation
+    kernel_radius_ = (kernel_size_ - 1) / 2; //size of unreachable border region (on each side)
+    border_size_ = max_displacement_ + kernel_radius_; //size of unreachable border region (on each side)
+
+    top_width_ = ceil((float)(paddedbottomwidth - border_size_*2) / (float)stride1_);
+    top_height_ = ceil((float)(paddedbottomheight - border_size_*2) / (float)stride1_);
+
+    OP_REQUIRES(context, top_width_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+    OP_REQUIRES(context, top_height_ >= 1, errors::InvalidArgument("Correlation cannot be done with current settings. Neighborhood and kernel don't fit in blob"));
+
+    // Given a center position in image 1, how many displaced positions in -x / +x direction do we consider in image 2 (neighborhoodGridWidth):
+    neighborhood_grid_radius_ = max_displacement_ / stride2_;
+    neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;
+
+    // Top Channels amount to displacement combinations in X and Y direction:
+    top_channels_ = neighborhood_grid_width_ * neighborhood_grid_width_;
+
+    // Allocate the memory for the output
+    Tensor* input1_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, input1_shape, &input1_grad_tensor));
+    Tensor* input2_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(1, input2_shape, &input2_grad_tensor));
+
+    auto device = context->eigen_gpu_device();
+
+    // rbots (These are the blobs that store the padded and dimension rearranged data
+    TensorShape rbot_shape;
+    rbot_shape.AddDim(num);
+    rbot_shape.AddDim(paddedbottomheight);
+    rbot_shape.AddDim(paddedbottomwidth);
+    rbot_shape.AddDim(channels);
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot1_gpu_tensor));
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, rbot_shape, &rbot2_gpu_tensor));
+
+    // Prepare for gradient computation
+    auto input1      = input1_tensor.flat<T>();
+    auto input2      = input2_tensor.flat<T>();
+    auto gradient    = gradient_tensor.flat<T>();
+    auto input1_grad = input1_grad_tensor->flat<T>();
+    auto input2_grad = input2_grad_tensor->flat<T>();
+
+    auto rbot1 = rbot1_gpu_tensor.flat<T>();
+    auto rbot2 = rbot2_gpu_tensor.flat<T>();
+
+    CorrelationGrad_GPU(device.stream(), input1_grad.data(), input2_grad.data(), rbot1.data(), rbot2.data(), input1.data(), input2.data(), gradient.data(), num, channels, height, width, paddedbottomheight, paddedbottomwidth, rsize);
+  }
+
+  void CorrelationGrad_GPU( const cudaStream_t& stream,
+                            T*                  input1_grad,
+                            T*                  input2_grad,
+                            T*                  rbot1,
+                            T*                  rbot2,
+                            const T*            input1,
+                            const T*            input2,
+                            const T*            gradient,
+                            const int           bnum,
+                            const int           bchannels,
+                            const int           bheight,
+                            const int           bwidth,
+                            const int           paddedheight,
+                            const int           paddedwidth,
+                            const int           rsize
+                          )
+  {
+    const int bwidthheight = bwidth * bheight;
+
+    cudaMemset(rbot1, 0, rsize*sizeof(T));
+    cudaMemset(rbot2, 0, rsize*sizeof(T));
+
+    int threads_per_block=16;
+    dim3 totalBlocksRearr((bwidthheight-1)/threads_per_block+1, bchannels, bnum);
+    const int pwidthheight = (bwidth + 2 * pad_size_) * (bheight + 2 * pad_size_);
+
+    blob_rearrange_kernel2<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input1,rbot1,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    blob_rearrange_kernel2<T><<<totalBlocksRearr,threads_per_block, 0, stream>>>
+            (input2,rbot2,bnum,bchannels,bwidth,bheight,bwidthheight,pad_size_,pwidthheight);
+
+    const int num = bnum;
+    const int channels = bchannels;
+    const int height = bheight;
+    const int width = bwidth;
+
+    const int bottomcount = channels * height * width;
+
+    int botThreadCount = bottomcount;
+
+    // CorrelationLayerBackward
+    if(corr_type_ == MULT) {
+
+        // == Run kernel Backward 0
+        dim3 totalBlocksBackward0(width, height, channels * num); //First dim is fastest
+        dim3 threadsPerBlockBackward0(THREADS_PER_WARP * WARPS_PER_BLOCK);
+        const int buffer_size_backw0 = ((int)ceil((float)(2 * kernel_radius_) / (float)stride1_) + 1) * top_channels_;
+
+        // == Run kernel Backward 0
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward0<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            input1_grad, rbot2, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+        // == Run kernel Backward 1
+        for(int n = 0; n < num; n++) {
+        CorrelateDataBackward1<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            rbot1, input2_grad, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+    } else if(corr_type_ == SUBT) {
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward0Subtract<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            input1_grad, rbot1, rbot2, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+
+        for(int n = 0; n < num; n++) {
+        //Bottom0:
+        CorrelateDataBackward1Subtract<T><<<LMBOPS_GET_BLOCKS(botThreadCount), LMBOPS_CUDA_NUM_THREADS, 0, stream>>>(
+            botThreadCount,
+            num, n, top_width_, top_height_, top_channels_,
+            max_displacement_, neighborhood_grid_radius_, neighborhood_grid_width_, kernel_radius_,
+            stride1_, stride2_,
+            width, height, paddedwidth, paddedheight, channels, bottomcount, pad_size_,
+            rbot1, rbot2, input2_grad, gradient
+            );
+
+        CHECK_CUDA_ERROR;
+        }
+    }
+  }
+private:
+  int kernel_size_;
+
+  int stride1_;
+  int stride2_;
+  int max_displacement_;
+
+  int pad_size_;
+
+  int num_;
+  int top_height_, top_width_;
+  int top_channels_;
+
+  // Correlation specific
+  bool do_abs_;
+
+  enum CorrType {MULT = 1, SUBT = 2};
+  CorrType corr_type_;
+
+  Tensor rbot1_gpu_tensor;
+  Tensor rbot2_gpu_tensor;
+
+  // Computed
+  int kernel_radius_;
+  int border_size_;
+  int neighborhood_grid_radius_, neighborhood_grid_width_;
+
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("CorrelationGrad")                                                   \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    CorrelationGradOp_GPU<type>);
+REG_KB(float)
+#undef REG_KB

--- a/src/cuda_helper.h
+++ b/src/cuda_helper.h
@@ -1,17 +1,17 @@
 //
 //  lmbspecialops - a collection of tensorflow ops
 //  Copyright (C) 2017  Benjamin Ummenhofer, Huizhong Zhou
-//  
+//
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-//  
+//
 //  This program is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //  GNU General Public License for more details.
-//  
+//
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
@@ -28,7 +28,7 @@ inline void _CHECK_CUDA_ERROR( const char* filename, const int line )
   if( error != cudaSuccess )
   {
     char str[1024]; str[0] = 0;
-    sprintf(str, "%s:%d: cuda error: %s\n", 
+    sprintf(str, "%s:%d: cuda error: %s\n",
            filename, line, cudaGetErrorString(error));
     throw std::runtime_error(str);
   }
@@ -41,17 +41,29 @@ inline void print_cuda_pointer_attributes( const void* ptr )
   char str[1024]; str[0] = 0;
   if( status != cudaSuccess )
   {
-    sprintf(str, "cuda error in 'print_cuda_pointer_attributes()': %s", 
+    sprintf(str, "cuda error in 'print_cuda_pointer_attributes()': %s",
         cudaGetErrorString(status));
     //throw std::runtime_error(str);
   }
   std::cerr << "\n" << ptr << "  " << str << "\n";
-  std::cerr << "memoryType: " 
-    << (attr.memoryType==cudaMemoryTypeHost ? "cudaMemoryTypeHost\n" : "cudaMemoryTypeDevice\n") 
+  std::cerr << "memoryType: "
+    << (attr.memoryType==cudaMemoryTypeHost ? "cudaMemoryTypeHost\n" : "cudaMemoryTypeDevice\n")
     << "device: " << attr.device << "\n"
     << "devicePointer: " << attr.devicePointer << "\n"
     << "hostPointer: " << attr.hostPointer << "\n"
     << "isManaged: " << attr.isManaged << "\n";
+}
+#define LMBOPS_CUDA_KERNEL_LOOP(i, n) \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; \
+       i < (n); \
+       i += blockDim.x * gridDim.x)
+
+// CUDA: use 512 threads per block
+const int LMBOPS_CUDA_NUM_THREADS = 512;
+
+// CUDA: number of blocks for threads.
+inline int LMBOPS_GET_BLOCKS(const int N) {
+  return (N + LMBOPS_CUDA_NUM_THREADS - 1) /LMBOPS_CUDA_NUM_THREADS;
 }
 
 

--- a/src/decode_flo_op.cc
+++ b/src/decode_flo_op.cc
@@ -62,7 +62,7 @@ class DecodeFloOp : public OpKernel {
                   errors::InvalidArgument("Invalid FLO data size, expected at least 12"));
     }
 
-    if (!data.starts_with("PIEH")) {
+    if (data.substr(0, 4) != StringPiece("PIEH")) {
       OP_REQUIRES(context, false,
                   errors::InvalidArgument("Invalid FLO header, expected 'PIEH'"));
     }

--- a/src/decode_pfm_op.cc
+++ b/src/decode_pfm_op.cc
@@ -190,11 +190,11 @@ class DecodePfmOp : public OpKernel {
                   errors::InvalidArgument("Invalid PFM data size, data too small for PFM file"));
     }
     int channels = channels_;
-    if (data.starts_with("PF")) {
+    if (data.substr(0, 2) == StringPiece("PF")) {
         OP_REQUIRES(context, channels == 0 || channels == 3,
                       errors::InvalidArgument("File has 3 channels, but output has only 1"));
         channels = 3;
-    } else if (data.starts_with("Pf")) {
+    } else if (data.substr(0, 2) == StringPiece("Pf")) {
         OP_REQUIRES(context, channels == 0 || channels == 1,
                           errors::InvalidArgument("File has 1 channels, but output has 3"));
         channels = 1;

--- a/src/decode_ppm_op.cc
+++ b/src/decode_ppm_op.cc
@@ -133,7 +133,7 @@ class DecodePpmOp : public OpKernel {
       OP_REQUIRES(context, false,
                   errors::InvalidArgument("Invalid PPM data size, data too small for PPM file"));
     }
-    if (!data.starts_with("P6")) {
+    if (data.substr(0, 2) != StringPiece("P6")) {
       OP_REQUIRES(context, false,
                   errors::InvalidArgument("Invalid PPM header, expected 'P6'"));
     }

--- a/src/flow_out_of_frame.cc
+++ b/src/flow_out_of_frame.cc
@@ -1,0 +1,98 @@
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+
+
+#define ROUND_2_INT(f) ((int)(f >= 0.0 ? (f + 0.5) : (f - 0.5)))
+
+
+using namespace tensorflow;
+
+REGISTER_OP("FlowOutOfFrame")
+	.Input("flow: float32")
+	.Input("occ: float32")
+	.Output("output: float32")
+    .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      	using namespace ::tensorflow::shape_inference;
+		ShapeHandle input_shape;
+		TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input_shape));
+		int num      = c->Value(c->Dim(input_shape, 0));
+      	int height   = c->Value(c->Dim(input_shape, 2));
+      	int width    = c->Value(c->Dim(input_shape, 3));
+		c->set_output(0, c->MakeShape({num, 1 , height ,width})) ;
+        return Status::OK();
+    });
+
+
+class FlowOutOfFrameOp : public OpKernel {
+
+	public:
+
+  	explicit FlowOutOfFrameOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+	void Compute(OpKernelContext* c) override {
+
+		TensorShape input_shape = c->input(0).shape();
+		int num      = input_shape.dim_size(0);
+        int channels = input_shape.dim_size(1);
+        int height   = input_shape.dim_size(2);
+        int width    = input_shape.dim_size(3);
+		int widthHeight = width*height;
+
+        TensorShape output_shape;
+        output_shape.AddDim(num);
+        output_shape.AddDim(1);
+        output_shape.AddDim(height);
+        output_shape.AddDim(width);
+        Tensor* output_tensor = 0;
+        OP_REQUIRES_OK(c, c->allocate_output(0, output_shape, &output_tensor));
+
+
+        float *top_ptr = output_tensor->flat<float>().data();
+    	const float* bot0_ptr = c->input(0).flat<float>().data();
+		const float* bot1_ptr = c->input(1).flat<float>().data();
+		for(int n=0; n<num; n++)
+		{
+			for(int y=0; y<height; y++)
+			{
+				for(int x=0; x<width; x++)
+				{
+					float fx = *bot0_ptr;
+					float fy = *(bot0_ptr+widthHeight);
+
+					int x2 = ROUND_2_INT(float(x)+fx);
+					int y2 = ROUND_2_INT(float(y)+fy);
+
+
+					if(x2>=0 && y2>=0 && x2<width && y2<height)
+					{
+						*top_ptr = *bot1_ptr;
+					}
+					else
+					{
+						*top_ptr = 1.0;
+					}
+
+					if(std::isnan(*bot1_ptr))
+						*top_ptr = *bot1_ptr;
+
+					top_ptr++;
+					bot1_ptr++;
+					bot0_ptr++;
+				}
+			}
+			bot0_ptr+=widthHeight;
+		}
+
+	}
+};
+
+
+REGISTER_KERNEL_BUILDER(Name("FlowOutOfFrame").Device(DEVICE_CPU), FlowOutOfFrameOp);
+
+

--- a/src/flowwarp.cc
+++ b/src/flowwarp.cc
@@ -1,0 +1,334 @@
+//
+//  lmbspecialops - a collection of tensorflow ops
+//  Copyright (C) 2017  Oezguen Cicek, Eddy Ilg
+//  
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//  
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//  
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "config.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include <math.h>
+
+#define min(a,b) ((a<b)?(a):(b))
+#define max(a,b) ((a>b)?(a):(b))
+
+using namespace tensorflow;
+
+REGISTER_OP("FlowWarp")
+  .Attr("T: {float}")
+  .Attr("fill_parameter: {'zero', 'not_a_number'} = 'zero'")
+  .Input("image: T")
+  .Input("flow: T")
+  .Output("warped: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) 
+    { 
+      // check if both inputs have rank 4
+      using namespace ::tensorflow::shape_inference;
+      ShapeHandle image_shape, flow_shape;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &image_shape));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4, &flow_shape));
+
+      // check if width and height are compatible
+      ShapeHandle image_shape2d;
+      c->Subshape(image_shape, -2, &image_shape2d);
+      ShapeHandle flow_shape2d;
+      c->Subshape(flow_shape, -2, &flow_shape2d);
+
+      ShapeHandle merged_shape2d;
+      TF_RETURN_IF_ERROR(c->Merge(image_shape2d, flow_shape2d, &merged_shape2d));
+      
+      // check if N is compatible for both inputs
+      DimensionHandle image_first_dim = c->Dim(image_shape, 0);
+      DimensionHandle flow_first_dim  = c->Dim(flow_shape,  0);
+
+      DimensionHandle d_first;
+      TF_RETURN_IF_ERROR(c->Merge(image_first_dim, flow_first_dim, &d_first));
+      
+      // check if C == 2 for the flow
+      DimensionHandle d_c;
+      TF_RETURN_IF_ERROR(c->WithValue(c->Dim(c->input(1), 1), 2, &d_c));
+        
+      // make sure warped has the same size as image
+      c->set_output(0, c->input(0));
+      return Status::OK();
+    })
+  .Doc(R"doc(
+Warps the image with the given flow.
+
+image: 
+  Input tensor of rank 4 and data format "NCHW".
+  
+flow: 
+  Input tensor of rank 4 and data format "NCHW".
+
+warped:
+  A tensor of rank 4 and data format "NCHW" for the warped image.
+)doc");
+  
+template<class T>
+class FlowWarpOp : public OpKernel 
+{
+public:
+  explicit FlowWarpOp(OpKernelConstruction* construction) 
+    :OpKernel(construction) 
+  {
+    std::string fill_parameter_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("fill_parameter", &fill_parameter_str));
+    if( fill_parameter_str == "zero" )
+      fill_parameter = ZERO;
+    else 
+      fill_parameter = NOT_A_NUMBER;
+  }
+
+  void Compute(OpKernelContext* context) override 
+  {
+    // Get the inputs   
+    const Tensor& image_tensor = context->input(0);
+    const Tensor& flow_tensor  = context->input(1);
+    
+    // Get the shapes
+    const TensorShape image_shape(image_tensor.shape());
+    
+    // Allocate the memory for the warped image
+    Tensor* warped_tensor = 0;
+    OP_REQUIRES_OK(context, context->allocate_output(0, image_shape, &warped_tensor));
+
+    // Prepare for warping
+    auto image  = image_tensor.flat<T>();
+    auto flow   = flow_tensor.flat<T>();
+    auto warped = warped_tensor->flat<T>();
+     
+    int num      = image_shape.dim_size(0);
+    int channels = image_shape.dim_size(1);
+    int height   = image_shape.dim_size(2);
+    int width    = image_shape.dim_size(3);
+    
+    FlowWarp_CPU(warped.data(), image.data(), flow.data(), num, channels, height, width);
+  }
+    
+  void FlowWarp_CPU( T*           warped,
+                     const T*     image,
+                     const T*     flow,
+                     const int    num,
+                     const int    channels,
+                     const int    height,
+                     const int    width
+                   ) 
+  {
+    const int wh_size = width * height;
+    const int whc_size = width * height * channels;
+      
+    float fill_value = fill_parameter == ZERO ? 0 : NAN;
+    
+    for(int n=0; n<num; n++)
+    {
+        int off = whc_size * n;
+        for(int x=0; x<width; x++)
+            for(int y=0; y<height; y++)
+            {
+                float fx = flow[2*wh_size*n + y*width + x];
+                float fy = flow[2*wh_size*n + wh_size + y*width + x];
+
+                float x2 = float(x) + fx;
+                float y2 = float(y) + fy;
+
+                if(x2>=0 && y2>=0 && x2<width && y2<height)
+                {
+                    int ix2_L = int(x2);
+                    int iy2_T = int(y2);
+                    int ix2_R = min(ix2_L+1, width-1);
+                    int iy2_B = min(iy2_T+1, height-1);
+
+                    float alpha=x2-ix2_L;
+                    float beta=y2-iy2_T;
+
+                    for(int c=0; c<channels; c++)
+                    {
+                        float TL = image[off + c*wh_size + iy2_T*width + ix2_L];
+                        float TR = image[off + c*wh_size + iy2_T*width + ix2_R];
+                        float BL = image[off + c*wh_size + iy2_B*width + ix2_L];
+                        float BR = image[off + c*wh_size + iy2_B*width + ix2_R];
+
+                        warped[off + c*wh_size + y*width + x] =
+                            (1-alpha)*(1-beta)*TL +
+                            alpha*(1-beta)*TR +
+                            (1-alpha)*beta*BL +
+                            alpha*beta*BR;
+                    }
+                }
+                else
+                {
+                    for(int c=0; c<channels; c++)
+                        warped[off + c*wh_size + y*width + x] = fill_value;
+                }
+            }
+    }
+  }
+private:
+    enum FillParameter {ZERO = 1, NOT_A_NUMBER = 2};
+    FillParameter fill_parameter;
+};
+  
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("FlowWarp")                                                          \
+    .Device(DEVICE_CPU)                                                       \
+    .TypeConstraint<type>("T"),                                         \
+    FlowWarpOp<type>);                                                    
+REG_KB(float)
+#undef REG_KB
+
+REGISTER_OP("FlowWarpGrad")
+  .Attr("T: {float}")
+  .Input("image: T")
+  .Input("flow: T")
+  .Input("gradient: T")
+  .Output("image_grad: T")
+  .Output("flow_grad: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) 
+    {
+      c->set_output(0, c->input(0));
+      c->set_output(1, c->input(1));
+      return Status::OK();
+    })
+  .Doc(R"doc(
+This computes the gradient for the op 'FlowWarp'. 
+)doc");
+  
+template <class T>
+class FlowWarpGradOp : public OpKernel 
+{
+public:
+  explicit FlowWarpGradOp(OpKernelConstruction* construction)
+    :OpKernel(construction) {}
+    
+  void Compute( OpKernelContext* context ) override 
+  {
+    // Get the inputs   
+    const Tensor& image_tensor     = context->input(0);
+    const Tensor& flow_tensor      = context->input(1); 
+    const Tensor& gradient_tensor  = context->input(2);
+    
+    // Get the shapes
+    const TensorShape image_shape(image_tensor.shape());
+    const TensorShape flow_shape(flow_tensor.shape());
+    
+    // Allocate the memory for the output
+    Tensor* image_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, image_shape, &image_grad_tensor));
+    Tensor* flow_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(1, flow_shape,  &flow_grad_tensor));
+    
+    // Prepare for gradient computation    
+    auto flow        = flow_tensor.flat<T>(); 
+    auto image       = image_tensor.flat<T>();
+    auto gradient    = gradient_tensor.flat<T>();
+    auto image_grad  = image_grad_tensor->flat<T>();
+    auto flow_grad   = flow_grad_tensor->flat<T>();
+
+    int num      = image_shape.dim_size(0);
+    int channels = image_shape.dim_size(1);
+    int height   = image_shape.dim_size(2);
+    int width    = image_shape.dim_size(3);
+    
+    FlowWarpGrad_CPU(image_grad.data(), flow_grad.data(), image.data(), flow.data(), gradient.data(), num, channels, height, width);
+  }
+ 
+  void FlowWarpGrad_CPU( T*           image_grad,
+                         T*           flow_grad,
+                         const T*     image,
+                         const T*     flow,
+                         const T*     gradient,
+                         const int    num,
+                         const int    channels,
+                         const int    height,
+                         const int    width
+                       ) 
+  {
+    const int wh_size = width * height;
+    const int whc_size = width * height * channels; 
+    
+    for(int i=0; i<num*whc_size; i++)
+        image_grad[i] = 0 ;
+    for(int i=0; i<num*whc_size; i++)
+        flow_grad[i] = 0 ;
+    
+    for(int n=0; n<num; n++)
+    {
+        int off = whc_size * n;
+        for(int x=0; x<width; x++)
+            for(int y=0; y<height; y++)
+            {
+                float fx = flow[2*wh_size*n + y*width + x];
+                float fy = flow[2*wh_size*n + wh_size + y*width + x];
+
+                float x2 = float(x) + fx;
+                float y2 = float(y) + fy;
+
+                if(x2>=0 && y2>=0 && x2<width && y2<height)
+                {
+                    int ix2_L = int(x2);
+                    int iy2_T = int(y2);
+                    int ix2_R = min(ix2_L+1, width-1);
+                    int iy2_B = min(iy2_T+1, height-1);
+
+                    float alpha=x2-ix2_L;
+                    float beta=y2-iy2_T;
+                    for(int c=0; c<channels; c++)
+                    {
+                        float warped_diff_value = gradient[off + c*wh_size + y*width + x];
+                        image_grad[off + c*wh_size + iy2_T*width + ix2_L] += warped_diff_value * (1-alpha)*(1-beta);
+                        image_grad[off + c*wh_size + iy2_T*width + ix2_R] += warped_diff_value * alpha*(1-beta);
+                        image_grad[off + c*wh_size + iy2_B*width + ix2_L] += warped_diff_value * (1-alpha)*beta;
+                        image_grad[off + c*wh_size + iy2_B*width + ix2_R] += warped_diff_value * alpha*beta;
+                    }
+
+                    float gamma = iy2_B - y2;
+                    float bot_diff = 0;
+                    for(int c=0; c<channels; c++)
+                    {
+                        float temp = 0;
+                        temp += gamma *     (image[off + c*wh_size + iy2_T*width + ix2_R] - image[off + c*wh_size + iy2_T*width + ix2_L]);
+                        temp += (1-gamma) * (image[off + c*wh_size + iy2_B*width + ix2_R] - image[off + c*wh_size + iy2_B*width + ix2_L]);
+
+                        bot_diff += gradient[off + c*wh_size + y*width + x] * temp;
+                    }
+                    flow_grad[2*wh_size*n + y*width + x] = bot_diff;
+
+                    gamma = ix2_R - x2;
+                    bot_diff = 0;
+                    for(int c=0; c<channels; c++)
+                    {
+                        float temp = 0;
+                        temp += gamma *     (image[off + c*wh_size + iy2_B*width + ix2_L] - image[off + c*wh_size + iy2_T*width + ix2_L]);
+                        temp += (1-gamma) * (image[off + c*wh_size + iy2_B*width + ix2_R] - image[off + c*wh_size + iy2_T*width + ix2_R]);
+
+                        bot_diff += gradient[off + c*wh_size + y*width + x] * temp;
+                    }
+                    flow_grad[2*wh_size*n + wh_size + y*width + x] = bot_diff;
+                }
+            }
+    }
+  }
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("FlowWarpGrad")                                                      \
+    .Device(DEVICE_CPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    FlowWarpGradOp<type>);                                                   
+REG_KB(float)
+#undef REG_KB

--- a/src/flowwarp_cuda.cu
+++ b/src/flowwarp_cuda.cu
@@ -1,0 +1,458 @@
+//
+//  lmbspecialops - a collection of tensorflow ops
+//  Copyright (C) 2017  Oezguen Cicek, Eddy Ilg
+//  
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//  
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//  
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#define EIGEN_USE_GPU
+#include "config.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "helper.h"
+#include "cuda_helper.h"
+#include "Eigen/Core"
+
+using namespace tensorflow;
+
+#define min(a,b) ((a<b)?(a):(b))
+#define max(a,b) ((a>b)?(a):(b))
+
+#define RA_TILE 32
+#define RA_ROWS 8
+
+#define FW_THREADS 32
+#define FW_TILE_X FW_THREADS
+#define FW_TILE_C FW_THREADS
+
+#define ZERO 1
+#define NOT_A_NUMBER 2
+
+namespace flow_warp_rearrange_kernel_internal
+{
+template <class T>
+__global__ void flow_warp_rearrange_kernel(const T* in, T* out, int num, int channels, int cblocks, int width, int height, int widthheight)
+{
+  __shared__ float buffer[RA_TILE][RA_TILE+1];
+
+  int n  = blockIdx.x/cblocks;
+  if(n>=num) return;
+
+  int c0 = (blockIdx.x%cblocks)*RA_TILE;
+  int x0 = blockIdx.y*RA_TILE;
+  int y  = blockIdx.z;
+
+  int xoff=threadIdx.x;
+  int coff=threadIdx.y;
+  int x=x0+xoff;
+
+  if(x<width)
+    for(int i=coff; i<RA_TILE && c0+i<channels; i+=RA_ROWS)
+        buffer[i][xoff] = in[((n*channels + c0 + i)*height + y)*width + x];
+
+  __syncthreads();
+
+  coff = threadIdx.x;
+  xoff = threadIdx.y;
+  int c = c0 + coff;
+
+  if(c<channels)
+    for(int j=xoff; j<RA_TILE && x0+j<width; j+=RA_ROWS)
+       out[((n*height + y)*width + x0+j)*channels + c] = buffer[coff][j];
+}
+}
+using namespace flow_warp_rearrange_kernel_internal;
+
+namespace flow_warp_kernel_smem_internal
+{
+template <class T>
+__global__ void flow_warp_kernel_smem(const T* image, const T* flow, T* warped, int num, int channels, int cblocks, int width, int wblocks, int height, int widthheight, float fillValue)
+{
+    int y = blockIdx.y;
+    int n = blockIdx.z;
+
+    __shared__ float x2_buf[FW_TILE_X], y2_buf[FW_TILE_X];
+    __shared__ float buffer[FW_TILE_C][FW_TILE_X+1];
+
+    int x;
+    int c;
+
+    x = blockIdx.x*FW_TILE_X + threadIdx.x;
+    if(threadIdx.y==0 && x<width)
+    {
+        x2_buf[threadIdx.x] = float(x) + flow[((2*n  )*height + y)*width + x];
+        y2_buf[threadIdx.x] = float(y) + flow[((2*n+1)*height + y)*width + x];
+    }
+
+    __syncthreads();
+
+    float x2 = x2_buf[threadIdx.y];
+    float y2 = y2_buf[threadIdx.y];
+
+    int ix2_L = int(x2);
+    int iy2_T = int(y2);
+    int ix2_R = min(ix2_L+1, width-1);
+    int iy2_B = min(iy2_T+1, height-1);
+
+    int off_TL = ((n*height + iy2_T)*width + ix2_L)*channels;
+    int off_TR = ((n*height + iy2_T)*width + ix2_R)*channels;
+    int off_BL = ((n*height + iy2_B)*width + ix2_L)*channels;
+    int off_BR = ((n*height + iy2_B)*width + ix2_R)*channels;
+
+    float alpha = x2-ix2_L;
+    float beta = y2-iy2_T;
+    float coeffTL = (1-alpha)*(1-beta);
+    float coeffTR = alpha*(1-beta);
+    float coeffBL = (1-alpha)*beta;
+    float coeffBR = alpha*beta;
+
+    for(int cb=0; cb<cblocks; cb++)
+    {
+        __syncthreads();
+
+        buffer[threadIdx.y][threadIdx.x] = fillValue;
+
+        __syncthreads();
+
+        c = cb*FW_TILE_C + threadIdx.x;
+        if(x2>=0 && y2>=0 && x2<width && y2<height && c<channels)
+            buffer[threadIdx.y][threadIdx.x] =  // buffer [x][c]
+                coeffTL * image[off_TL + c] +
+                coeffTR * image[off_TR + c] +
+                coeffBL * image[off_BL + c] +
+                coeffBR * image[off_BR + c];
+
+        __syncthreads();
+
+        c = cb*FW_TILE_C + threadIdx.y;
+        x = blockIdx.x*FW_TILE_X + threadIdx.x;
+        if(c<channels && x<width)
+            warped[((n*channels+c)*height + y)*width + x] = buffer[threadIdx.x][threadIdx.y];
+    }
+}
+}
+using namespace flow_warp_kernel_smem_internal;
+
+namespace flow_warp_backward_kernel_no_smem_internal
+{
+template <class T>
+__global__ void flow_warp_backward_kernel_no_smem(
+        const T* image_data, T* image_diff, const T* flow_data, T* flow_diff, const T* warped_diff,
+        int num, int channels, int cblocks, int width, int wblocks, int height, int widthheight)
+{
+    int x = blockIdx.x*FW_TILE_X + threadIdx.x;
+    if(x>=width)
+        return;
+
+    int y = blockIdx.y;
+    int n = blockIdx.z;
+
+    float x2 = float(x) + flow_data[((2*n  )*height + y)*width + x];
+    float y2 = float(y) + flow_data[((2*n+1)*height + y)*width + x];
+
+    if(x2>=0.f && y2>=0.f && x2<width && y2<height)
+    {
+        int ix2_L = int(x2);
+        int iy2_T = int(y2);
+        int ix2_R = min(ix2_L+1, width-1);
+        int iy2_B = min(iy2_T+1, height-1);
+
+        float alpha=x2-ix2_L;
+        float beta=y2-iy2_T;
+        for(int c=0; c<channels; c++)
+        {
+            int ch_off = (n*channels + c)*height;
+            float warped_diff_value = warped_diff[(ch_off + y)*width + x];
+            atomicAdd(&image_diff[(ch_off + iy2_T)*width + ix2_L], warped_diff_value * (1-alpha)*(1-beta));
+            atomicAdd(&image_diff[(ch_off + iy2_T)*width + ix2_R], warped_diff_value * alpha*(1-beta));
+            atomicAdd(&image_diff[(ch_off + iy2_B)*width + ix2_L], warped_diff_value * (1-alpha)*beta);
+            atomicAdd(&image_diff[(ch_off + iy2_B)*width + ix2_R], warped_diff_value * alpha*beta);
+        }
+
+        float gamma = iy2_B - y2;
+        float bot_diff = 0;
+        for(int c=0; c<channels; c++)
+        {
+            int ch_off = (n*channels + c)*height;
+            float temp = 0;
+            temp += gamma *     (image_data[(ch_off + iy2_T)*width + ix2_R] - image_data[(ch_off + iy2_T)*width + ix2_L]);
+            temp += (1-gamma) * (image_data[(ch_off + iy2_B)*width + ix2_R] - image_data[(ch_off + iy2_B)*width + ix2_L]);
+
+            bot_diff += warped_diff[(ch_off + y)*width + x] * temp;
+        }
+        flow_diff[(2*n*height + y)*width + x] = bot_diff;
+
+        gamma = ix2_R - x2;
+        bot_diff = 0;
+        for(int c=0; c<channels; c++)
+        {
+            int ch_off = (n*channels + c)*height;
+            float temp = 0;
+            temp += gamma *     (image_data[(ch_off + iy2_B)*width + ix2_L] - image_data[(ch_off + iy2_T)*width + ix2_L]);
+            temp += (1-gamma) * (image_data[(ch_off + iy2_B)*width + ix2_R] - image_data[(ch_off + iy2_T)*width + ix2_R]);
+
+            bot_diff += warped_diff[(ch_off + y)*width + x] * temp;
+        }
+        flow_diff[((2*n+1)*height + y)*width + x] = bot_diff;
+    }
+}
+}
+using namespace flow_warp_backward_kernel_no_smem_internal;
+
+template <class T>
+class FlowWarpOp_GPU : public OpKernel 
+{
+public:
+  explicit FlowWarpOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction) 
+  {
+    std::string fill_parameter_str;
+    OP_REQUIRES_OK(construction, construction->GetAttr("fill_parameter", &fill_parameter_str));
+    if( fill_parameter_str == "zero" )
+      fill_parameter = ZERO;
+    else 
+      fill_parameter = NOT_A_NUMBER;
+  }
+  
+  void Compute( OpKernelContext* context ) override 
+  {
+    // Get the inputs
+    const Tensor& image_tensor = context->input(0);
+    const Tensor& flow_tensor  = context->input(1);
+    
+    // Get the shapes
+    const TensorShape image_shape(image_tensor.shape());
+    
+    // Allocate memory for the warped image
+    Tensor* warped_tensor = 0;
+    OP_REQUIRES_OK(context, context->allocate_output(0, image_shape, &warped_tensor));
+    
+    // Prepare for warping
+    auto image = image_tensor.flat<T>();
+    auto flow  = flow_tensor.flat<T>();
+    auto warped = warped_tensor->flat<T>();
+    
+    int num      = image_shape.dim_size(0);
+    int channels = image_shape.dim_size(1);
+    int height   = image_shape.dim_size(2);
+    int width    = image_shape.dim_size(3);
+    
+    // Prepare transposed image
+    TensorShape transposed_image_shape;
+    transposed_image_shape.AddDim(num);
+    transposed_image_shape.AddDim(height);
+    transposed_image_shape.AddDim(width);
+    transposed_image_shape.AddDim(channels);
+    OP_REQUIRES_OK(context, context->allocate_temp(DT_FLOAT, transposed_image_shape, &transposed_image_tensor));
+    auto trans_image =  transposed_image_tensor.flat<T>();
+    
+    auto device = context->eigen_gpu_device();
+    
+    int nan = 0xFFE00000;
+    float nanf = *(reinterpret_cast<float*>(&nan));
+    float fill_value = fill_parameter == ZERO ? 0 : nanf;
+    
+    FlowWarp_GPU(device.stream(), warped.data(), trans_image.data(), image.data(), flow.data(), fill_value, num, channels, height, width);
+  }
+  
+  void FlowWarp_GPU(const cudaStream_t& stream,
+                    T*                  warped, 
+                    T*                  trans_image, 
+                    const T*            image, 
+                    const T*            flow,
+                    const float         fill_value,
+                    const int           num, 
+                    const int           channels, 
+                    const int           height, 
+                    const int           width
+                   )
+  {
+    const int wh_size = width * height;
+    const int whc_size = width * height * channels; 
+    
+    cudaMemset(warped, fill_value, width*height*channels*num*sizeof(T));
+    
+    #ifdef DISPLAY_TIMINGS
+      caffe::Timer t1;
+      t1.Start();
+    #endif
+      
+    dim3 rearrangeThreads(RA_TILE, RA_ROWS, 1);
+    int cblocks = ((channels-1)/RA_TILE+1);
+    dim3 rearrangeBlocks(cblocks*num, (width-1)/RA_TILE+1, height);
+    
+    flow_warp_rearrange_kernel<T><<<rearrangeBlocks, rearrangeThreads, 0, stream>>>(
+        image,
+        trans_image,
+        num,
+        channels,
+        cblocks,
+        width,
+        height,
+        wh_size
+    );
+
+    CHECK_CUDA_ERROR;
+    
+    #ifdef DISPLAY_TIMINGS
+    t1.Stop();
+    LOG(INFO) << "rearrange time " << t1.MilliSeconds() << "ms";
+    #endif
+
+    {
+    #ifdef DISPLAY_TIMINGS
+      caffe::Timer t2;
+      t2.Start();
+    #endif
+    int wblocks = ((width-1)/FW_TILE_X+1);
+    int cblocks = ((channels-1)/FW_TILE_C+1);
+    dim3 warpThreads(FW_TILE_X, FW_TILE_C);
+    dim3 warpBlocks(wblocks, height, num);
+    
+    flow_warp_kernel_smem<T><<<warpBlocks, warpThreads, 0, stream>>>(
+        trans_image,
+        flow,
+        warped,
+        num,
+        channels,
+        cblocks,
+        width,
+        wblocks,
+        height,
+        wh_size,
+        fill_value
+        );
+    
+    CHECK_CUDA_ERROR;
+    
+    #ifdef DISPLAY_TIMINGS
+      t2.Stop();
+      LOG(INFO) << "warp time 1a: " << t2.MilliSeconds() << "ms";
+    #endif
+    }
+  }
+private:
+  int fill_parameter;
+  Tensor  transposed_image_tensor;
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("FlowWarp")                                                          \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    FlowWarpOp_GPU<type>);                                                    
+REG_KB(float)
+#undef REG_KB
+
+
+template <class T>
+class FlowWarpGradOp_GPU : public OpKernel 
+{
+public:
+  explicit FlowWarpGradOp_GPU(OpKernelConstruction* construction)
+    :OpKernel(construction) {}
+  
+  void Compute( OpKernelContext* context ) override 
+  {
+    // Get the inputs   
+    const Tensor& image_tensor     = context->input(0);
+    const Tensor& flow_tensor      = context->input(1); 
+    const Tensor& gradient_tensor  = context->input(2);
+    
+    // Get the shapes
+    const TensorShape image_shape(image_tensor.shape());
+    const TensorShape flow_shape(flow_tensor.shape());
+    
+    // Allocate the memory for the output
+    Tensor* image_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, image_shape, &image_grad_tensor));
+    Tensor* flow_grad_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(1, flow_shape,  &flow_grad_tensor));
+    
+    // Prepare for gradient computation    
+    auto flow        = flow_tensor.flat<T>(); 
+    auto image       = image_tensor.flat<T>();
+    auto gradient    = gradient_tensor.flat<T>();
+    auto image_grad  = image_grad_tensor->flat<T>();
+    auto flow_grad   = flow_grad_tensor->flat<T>();
+
+    int num      = image_shape.dim_size(0);
+    int channels = image_shape.dim_size(1);
+    int height   = image_shape.dim_size(2);
+    int width    = image_shape.dim_size(3);
+    
+    auto device = context->eigen_gpu_device();
+    
+    FlowWarpGrad_GPU(device.stream(), image_grad.data(), flow_grad.data(), image.data(), flow.data(), gradient.data(), num, channels, height, width);
+  }
+  
+  void FlowWarpGrad_GPU( const cudaStream_t& stream,
+                         T*                  image_grad,
+                         T*                  flow_grad,
+                         const T*            image,
+                         const T*            flow,
+                         const T*            gradient,
+                         const int           num,
+                         const int           channels,
+                         const int           height,
+                         const int           width
+                       ) 
+  {
+    const int wh_size = width * height;
+    const int whc_size = width * height * channels;  
+    
+    cudaMemset(image_grad, 0, width*height*channels*num*sizeof(float));
+    cudaMemset(flow_grad, 0, width*height*2*num*sizeof(float));
+    
+    #ifdef DISPLAY_TIMINGS
+      caffe::Timer t3a;
+      t3a.Start();
+    #endif
+      
+    int wblocks = ((width-1)/FW_TILE_X+1);
+    int cblocks = ((channels-1)/FW_TILE_C+1);
+    dim3 warpThreads(FW_TILE_X,1);
+    dim3 warpBlocks(wblocks, height, num);
+    
+    flow_warp_backward_kernel_no_smem<T><<<warpBlocks, warpThreads, 0, stream>>>(
+        image,
+        image_grad,
+        flow,
+        flow_grad,
+        gradient,
+        num,
+        channels,
+        cblocks,
+        width,
+        wblocks,
+        height,
+        wh_size
+    );
+    
+    CHECK_CUDA_ERROR;
+
+    #ifdef DISPLAY_TIMINGS
+      t3a.Stop();
+      LOG(INFO) << "backward time 1a: " << t3a.MilliSeconds() << "ms";
+    #endif
+  }
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("FlowWarpGrad")                                                      \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    FlowWarpGradOp_GPU<type>);                                               
+REG_KB(float)
+#undef REG_KB

--- a/src/leakyrelu.cc
+++ b/src/leakyrelu.cc
@@ -22,7 +22,7 @@
 
 using namespace tensorflow;
 
-REGISTER_OP("LeakyRelu")
+REGISTER_OP("LeakyReluLmb")
   .Attr("T: {float, double}")
   .Attr("leak: float = 0.1")
   .Input("input: T")
@@ -48,10 +48,10 @@ output:
 
 
 template <class T>
-class LeakyReluOp : public OpKernel 
+class LeakyReluLmbOp : public OpKernel
 {
 public:
-  explicit LeakyReluOp(OpKernelConstruction* construction)
+  explicit LeakyReluLmbOp(OpKernelConstruction* construction)
     :OpKernel(construction)
   { 
     float leak_tmp;
@@ -87,10 +87,10 @@ private:
 
 #define REG_KB(type)                                                          \
 REGISTER_KERNEL_BUILDER(                                                      \
-    Name("LeakyRelu")                                                         \
+    Name("LeakyReluLmb")                                                         \
     .Device(DEVICE_CPU)                                                       \
     .TypeConstraint<type>("T"),                                               \
-    LeakyReluOp<type>);                                                       
+    LeakyReluLmbOp<type>);
 REG_KB(float)
 REG_KB(double)
 #undef REG_KB
@@ -98,7 +98,7 @@ REG_KB(double)
 
 
 
-REGISTER_OP("LeakyReluGrad")
+REGISTER_OP("LeakyReluLmbGrad")
   .Attr("T: {float, double}")
   .Attr("leak: float")
   .Input("gradients: T")
@@ -110,15 +110,15 @@ REGISTER_OP("LeakyReluGrad")
       return Status::OK();
     })
   .Doc(R"doc(
-This computes the gradient for the op 'LeakyRelu'. 
+This computes the gradient for the op 'LeakyReluLmb'.
 )doc");
 
 
 template <class T>
-class LeakyReluGradOp : public OpKernel 
+class LeakyReluLmbGradOp : public OpKernel
 {
 public:
-  explicit LeakyReluGradOp(OpKernelConstruction* construction)
+  explicit LeakyReluLmbGradOp(OpKernelConstruction* construction)
     :OpKernel(construction)
   {
     float leak_tmp;
@@ -162,10 +162,10 @@ private:
 
 #define REG_KB(type)                                                          \
 REGISTER_KERNEL_BUILDER(                                                      \
-    Name("LeakyReluGrad")                                                     \
+    Name("LeakyReluLmbGrad")                                                     \
     .Device(DEVICE_CPU)                                                       \
     .TypeConstraint<type>("T"),                                               \
-    LeakyReluGradOp<type>);                                                   
+    LeakyReluLmbGradOp<type>);
 REG_KB(float)
 REG_KB(double)
 #undef REG_KB

--- a/src/resample.cc
+++ b/src/resample.cc
@@ -1,0 +1,75 @@
+#include "config.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Resample")
+  .Attr("T: {float, double}")
+  .Attr("width: int")
+  .Attr("height: int")
+  .Attr("antialias: bool=True")
+  .Attr("type: {'NEAREST', 'CUBIC', 'LINEAR'} = 'LINEAR'")
+  .Input("input:T")
+  .Output("output: T")
+  .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c)
+    {
+      using namespace ::tensorflow::shape_inference;
+	  int width, height;
+	  c->GetAttr("width", &width);
+	  c->GetAttr("height", &height);
+	  c->set_output(0, c->MakeShape({ c->Dim(c->input(0), 0),
+						              c->Dim(c->input(0), 1),
+											 height,
+											 width
+										  }
+										  ));
+      return Status::OK();
+    })
+  .Doc(R"doc(
+  Resamples an input with a specified width and height
+  input:
+  	the input tensor to resample
+  type:
+    the resample type CUBIC, LINEAR or NEAREST
+  width:
+	width of the output
+  height:
+    height of the output
+  antialias:
+    bool flag to choose if antialiasing is needed or not.
+    Default value is True.
+  output:
+  	the output containing resampled output
+)doc");
+
+
+template <class T>
+class ResampleOp: public OpKernel
+{
+	int width;
+	int height;
+public:
+  explicit ResampleOp(OpKernelConstruction* c)
+    :OpKernel(c)
+  {
+	OP_REQUIRES_OK(c,c->GetAttr("width", &width));
+	OP_REQUIRES_OK(c,c->GetAttr("height", &height));
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+	  //throw an error here
+  }
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("Resample")                                                         \
+    .Device(DEVICE_CPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    ResampleOp<type>);
+REG_KB(float)
+REG_KB(double)
+#undef REG_KB

--- a/src/resample_cuda.cu
+++ b/src/resample_cuda.cu
@@ -1,0 +1,250 @@
+#define EIGEN_USE_GPU
+#include "config.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "helper.h"
+#include "cuda_helper.h"
+
+#define FILTER_BICUBIC 0
+#define FILTER_BOX 1
+#define FILTER_TRIANGLE 2
+
+
+using namespace tensorflow;
+
+namespace resample_kernel_internal
+{
+	static __device__ __forceinline__ float bicubicCoeff(float x_)
+	{
+		float x = fabsf(x_);
+		if (x <= 1.0f)     return x * x * (1.5f * x - 2.5f) + 1.0f;
+		else if (x < 2.0f) return x * (x * (-0.5f * x + 2.5f) - 4.0f) + 2.0f;
+		else               return 0.0f;
+	}
+
+	static __device__ __forceinline__ float boxCoeff(float x)
+	{
+		if (-0.5 <= x  && x<0.5) return 1.0;
+		return 0;
+	}
+
+	static __device__ __forceinline__ float triangleCoeff(float x)
+	{
+		if (-1<=x && x<0) return x+1;
+		if (0<=x && x<=1) return 1-x;
+		return 0;
+	}
+
+	template <typename T>
+	__global__ void NearestNeighborKernel(
+			const int nthreads,
+			const int in_channelsize,
+			const int out_channelsize,
+			const T* in_ptr,
+			const int in_width,
+			const int in_height,
+			const float fx,
+			const float fy,
+			T* out_ptr,
+			const int out_width,
+			const int out_height)
+	{
+		LMBOPS_CUDA_KERNEL_LOOP(index, nthreads)
+		{
+			int c = index / out_channelsize;
+			int x_out = (index % out_channelsize) % out_width;
+			int y_out = (index % out_channelsize) / out_width;
+
+			float x_in = x_out * fx + fy / 2.0f - 0.5f;
+			float y_in = y_out * fy + fx / 2.0f - 0.5f;
+
+			int x_in_round = round(x_in);
+			int y_in_round = round(y_in);
+
+			out_ptr[index] = in_ptr[c*in_channelsize + y_in_round*in_width+x_in_round];
+		}
+	}
+	template <typename T>
+		__global__ void InterpolationKernel(
+				const int nthreads,
+				const int in_channelsize,
+				const int out_channelsize,
+				const T* in_ptr,
+				const int in_width,
+				const int in_height,
+				const float fx,
+				const float fy,
+				T* out_ptr,
+				const int out_width,
+				const int out_height,
+				int filter_type,
+				int kernel_width,
+				const bool antialias)
+		{
+			LMBOPS_CUDA_KERNEL_LOOP(index, nthreads)
+			{
+				int c = index / out_channelsize;
+				int x_out = (index % out_channelsize) % out_width;
+				int y_out = (index % out_channelsize) / out_width;
+
+				float x_in = x_out * fx + fy / 2.0f - 0.5f;
+				float y_in = y_out * fy + fx / 2.0f - 0.5f;
+
+				int x_in_round = round(x_in);
+				int y_in_round = round(y_in);
+
+				T sum=0;
+				T wsum=0;
+
+				float ax = 1.0f / (antialias ? fx : 1.0f);
+				float ay = 1.0f / (antialias ? fy : 1.0f);
+				int rx = (fx < 1.0f) ? 2 : ceil(float(kernel_width)/ax);
+				int ry = (fy < 1.0f) ? 2 : ceil(float(kernel_width)/ay);
+
+				for(int y=y_in_round-ry; y<=y_in_round+ry; y++)
+					for(int x=x_in_round-rx; x<=x_in_round+rx; x++)
+					{
+						if(y<0 || x<0) continue;
+						if(y>=in_height || x>=in_width) continue;
+
+						float dx = x_in - x;
+						float dy = y_in - y;
+
+						float w;
+						if(filter_type == FILTER_BICUBIC)   w = ax*bicubicCoeff(ax*dx) * ay*bicubicCoeff(ay*dy);
+						else if(filter_type == FILTER_BOX)  w = ax*boxCoeff(ax*dx) * ay*boxCoeff(ay*dy);
+						else                                w = ax*triangleCoeff(ax*dx) * ay*triangleCoeff(ay*dy);
+						sum += w * in_ptr[c*in_channelsize + y*in_width+x];
+						wsum += w;
+					}
+
+				out_ptr[index] = (!wsum) ? 0 : (sum / wsum);
+			}
+		}
+
+}
+
+
+using namespace resample_kernel_internal;
+
+template <class T>
+class ResampleOp_GPU: public OpKernel
+{
+	int width;
+	int height;
+	enum InterpolationType {NEAREST = 1, CUBIC = 2, LINEAR = 3};
+    InterpolationType type;
+	bool antialias;
+
+public:
+  explicit ResampleOp_GPU(OpKernelConstruction* context)
+    :OpKernel(context)
+  {
+	std::string type_str;
+	OP_REQUIRES_OK(context,context->GetAttr("width" ,  &width));
+	OP_REQUIRES_OK(context,context->GetAttr("height",  &height));
+	OP_REQUIRES_OK(context,context->GetAttr("type"  ,  &type_str));
+	OP_REQUIRES_OK(context,context->GetAttr("antialias"  ,  &antialias));
+    if( type_str == "NEAREST" )
+      type = NEAREST;
+    else if (type_str == "LINEAR")
+      type = LINEAR;
+	else if (type_str == "CUBIC")
+	  type = CUBIC;
+  }
+
+  void Compute( OpKernelContext* context ) override
+  {
+    const Tensor& input_tensor = context->input(0);
+    auto input = input_tensor.flat<T>();
+    const TensorShape input_shape(input_tensor.shape());
+
+	const int num = input_shape.dim_size(0);
+	const int channels = input_shape.dim_size(1);
+	const int orig_height =  input_shape.dim_size(2);
+	const int orig_width =  input_shape.dim_size(3);
+
+	TensorShape out_shape;
+
+	out_shape.AddDim(num);
+	out_shape.AddDim(channels);
+	out_shape.AddDim(height);
+	out_shape.AddDim(width);
+
+    Tensor* output_tensor = 0;
+    OP_REQUIRES_OK(context, context->allocate_output(0, out_shape, &output_tensor));
+
+	auto output = output_tensor->flat<T>();
+    auto device = context->eigen_gpu_device();
+
+	const float fx = float(orig_width)/float(width);
+    const float fy = float(orig_height)/float(height);
+
+	int out_size = width*height*channels*num;
+	int out_channelsize = width*height;
+	int in_channelsize = orig_width*orig_height;
+
+	if(type==NEAREST){
+		NearestNeighborKernel<T><<< LMBOPS_GET_BLOCKS(out_size), LMBOPS_CUDA_NUM_THREADS, 0, device.stream() >>>(
+				out_size,
+				in_channelsize,
+				out_channelsize,
+				(T*)input.data(),
+				orig_width,
+				orig_height,
+				fx,
+				fy,
+				(T*)output.data(),
+				width,
+				height
+				);
+		CHECK_CUDA_ERROR;
+	}
+	else if (type == CUBIC || type == LINEAR)
+	{
+	  int filter_type;
+      if(type == CUBIC)
+          filter_type = FILTER_BICUBIC;
+      else if(type == LINEAR)
+          filter_type = FILTER_TRIANGLE;
+
+	  bool is_downsample = (fx > 1) || (fy > 1);
+	  bool should_antialias = antialias && is_downsample;
+	  int kernel_width;
+
+      if(filter_type == FILTER_BICUBIC)   kernel_width = 4;
+      else if(filter_type == FILTER_BOX)  kernel_width = 1;
+      else                                kernel_width = 2;
+
+	  InterpolationKernel<T><<<LMBOPS_GET_BLOCKS(out_size), LMBOPS_CUDA_NUM_THREADS>>>(
+			  out_size,
+			  in_channelsize,
+			  out_channelsize,
+			  (T*)input.data(),
+			  orig_width,
+			  orig_height,
+			  fx,
+			  fy,
+			  (T*)output.data(),
+			  width,
+			  height,
+			  filter_type,
+			  kernel_width,
+			  should_antialias);
+	  CHECK_CUDA_ERROR
+	}
+	else
+	{
+	  OP_REQUIRES(context,"Type must be NEAREST, CUBIC or LINEAR", errors::InvalidArgument("Unsupported resampling type") );
+	}
+  }
+};
+
+#define REG_KB(type)                                                          \
+REGISTER_KERNEL_BUILDER(                                                      \
+    Name("Resample")                                                         \
+    .Device(DEVICE_GPU)                                                       \
+    .TypeConstraint<type>("T"),                                               \
+    ResampleOp_GPU<type>);
+REG_KB(float)
+REG_KB(double)
+#undef REG_KB


### PR DESCRIPTION
* NVCC's CUDA gencode parameters are configured automatically based on available GPU devices using the [`cuda_select_nvcc_arch_flags()` macro](https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindCUDA/select_compute_arch.cmake) included in the [FindCUDA](https://cmake.org/cmake/help/latest/module/FindCUDA.html) module.
  
  If necessary, the `CUDA_ARCH_LIST` environment variable or CMake variable can be used to
generate code for specific architectures or compute capabilities instead.
`CUDA_ARCH_LIST` accepts a list of architecture names (e.g. Pascal, Volta, etc) and/or
compute capability versions (6.1, 7.0, etc).

* Add support for building and installing via setup.py. Makes use of [cmake-setuptools](https://github.com/raydouglass/cmake_setuptools). The previous CMake-based workflow is still supported.

* Includes fixes from other branches, such as the tensorflow 1.9 patch (#6), improved TensorFlow build flag configuration (#12) and LeakyRelu op shadowing by TensorFlow (#14).

* Updated dependencies: `webp` 0.6.0 -> 1.0.2, `lz4` 1.3.1 -> 1.9.1.

* Updated the readme to use `setup.py` for building & installation. Moved the previous build instructions under the new 'Development' section.